### PR TITLE
feat: ship PodMonitor template for automatic Prometheus discovery

### DIFF
--- a/charts/infercost/templates/NOTES.txt
+++ b/charts/infercost/templates/NOTES.txt
@@ -51,6 +51,16 @@ GETTING STARTED:
 
 6. Prometheus metrics are available at:
    {{ include "infercost.fullname" . }}-metrics.{{ include "infercost.namespace" . }}.svc:{{ .Values.metrics.service.port }}/metrics
+{{- if and .Values.prometheus.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+
+   A PodMonitor has been created so kube-prometheus-stack will discover the
+   controller automatically. Verify scraping with:
+     kubectl get podmonitor -n {{ include "infercost.namespace" . }} {{ include "infercost.fullname" . }}
+{{- else if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+
+   prometheus-operator CRDs not detected — install kube-prometheus-stack and
+   re-run `helm upgrade` to auto-create a PodMonitor for scraping.
+{{- end }}
 {{- end }}
 
 ---

--- a/charts/infercost/templates/podmonitor.yaml
+++ b/charts/infercost/templates/podmonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.prometheus.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "infercost.fullname" . }}
+  {{- if .Values.prometheus.podMonitor.namespace }}
+  namespace: {{ .Values.prometheus.podMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "infercost.namespace" . }}
+  {{- end }}
+  labels:
+    {{- include "infercost.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ include "infercost.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "infercost.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+    interval: {{ .Values.prometheus.podMonitor.interval }}
+    {{- if .Values.metrics.secure }}
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    {{- end }}
+    {{- with .Values.prometheus.podMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.prometheus.podMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/infercost/values.yaml
+++ b/charts/infercost/values.yaml
@@ -118,6 +118,21 @@ fullnameOverride: ""
 
 # Prometheus monitoring integration
 prometheus:
+  # PodMonitor scrapes the controller pod directly.
+  # Default-on because it's the recommended path for kube-prometheus-stack users —
+  # no Service required, works out of the box. The template is guarded by an
+  # APIVersions check so clusters without prometheus-operator CRDs are unaffected.
+  podMonitor:
+    enabled: true
+    namespace: ""
+    interval: 30s
+    labels: {}
+    relabelings: []
+    metricRelabelings: []
+
+  # ServiceMonitor is an alternative for users who prefer Service-based scraping
+  # or run a prometheus-operator setup that only consumes ServiceMonitors.
+  # Leave one of podMonitor or serviceMonitor enabled, not both.
   serviceMonitor:
     enabled: false
     namespace: ""


### PR DESCRIPTION
## Summary

Fresh Helm installs on kube-prometheus-stack clusters were producing empty Grafana dashboards because nothing pointed Prometheus at the InferCost controller. The chart shipped a ServiceMonitor template but it defaulted to disabled, and a hand-rolled PodMonitor with the obvious selector (\`app.kubernetes.io/name: infercost\`) silently misses the pod unless the author also knows to include the \`control-plane: controller-manager\` label.

This PR ships a PodMonitor that works out of the box.

## What changed

- **New template** \`charts/infercost/templates/podmonitor.yaml\` — gated by \`prometheus.podMonitor.enabled\` (default \`true\`) AND \`.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"\` so clusters without prometheus-operator CRDs aren't broken.
- **Selector** uses the existing \`infercost.selectorLabels\` helper so it always matches whatever labels the deployment actually applies (no silent-miss trap).
- **Port** references the named container port \`metrics\` so it survives any future port renumbering in values.
- **values.yaml** gets a new \`prometheus.podMonitor\` block with \`interval\`, \`labels\`, \`relabelings\`, \`metricRelabelings\`. ServiceMonitor is unchanged and remains available as an alternative.
- **NOTES.txt** now surfaces PodMonitor status on install so users can see at a glance whether scraping is wired up.

## Verification

\`\`\`
$ helm lint charts/infercost
==> Linting charts/infercost
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template infercost charts/infercost --api-versions monitoring.coreos.com/v1 --show-only templates/podmonitor.yaml
# renders a valid PodMonitor with selector matching the deployment pod template

$ helm template infercost charts/infercost --show-only templates/podmonitor.yaml
# empty — template silently skipped without prometheus-operator CRDs
\`\`\`

## Acceptance (from #18)

- [x] Helm install + kube-prometheus-stack → Prometheus discovers the pod automatically
- [x] \`prometheus.podMonitor.enabled: false\` cleanly disables the template
- [x] Works without prometheus-operator CRDs (template is a no-op)

Closes #18