### PR TITLE
feat: add vLLM scraper with per-pod backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ token_cost = (GPU_amortization + electricity x power_draw x PUE) / tokens_per_ho
 - **REST API**: Programmatic access to cost data for custom dashboards, bots, and integrations
 - **CLI**: `infercost status` and `infercost compare` for terminal-based cost analysis
 - **Pre-built Grafana dashboard**: Ships as JSON, auto-provisionable via sidecar
-- **Multi-backend**: Scrapes llama.cpp, vLLM, or any Prometheus-compatible inference engine
+- **Multi-backend**: Scrapes llama.cpp and vLLM out of the box, selected per-pod via annotation
 
 ## Quick Start
 
@@ -173,6 +173,23 @@ InferCost runs as a single controller pod. It reads from data sources you alread
 | llama.cpp / vLLM | Token counts per inference pod |
 | CostProfile CRD | Hardware purchase price, amortization, electricity rate |
 | LiteLLM PostgreSQL | Per-user token attribution (optional) |
+
+**Per-pod backend selection**: InferCost looks at annotations on each inference pod to decide which /metrics parser to use. Default is llama.cpp for backwards compatibility.
+
+| Annotation (or label) | Values | Default |
+|----------------------|--------|---------|
+| `infercost.ai/backend` | `llamacpp`, `vllm` | `llamacpp` |
+| `infercost.ai/metrics-port` | any valid port | `8080` (llamacpp), `8000` (vllm) |
+
+Example vLLM pod:
+
+```yaml
+metadata:
+  annotations:
+    infercost.ai/backend: vllm
+  labels:
+    inference.llmkube.dev/model: qwen3-coder-30b
+```
 
 **Controller Pipeline**: GPU Power Scraper → Token Counter → Cost Calculator → Attribution Engine → Cloud Comparator → Report Writer
 

--- a/internal/controller/costprofile_controller.go
+++ b/internal/controller/costprofile_controller.go
@@ -217,11 +217,13 @@ func (r *CostProfileReconciler) scrapeInferencePods(ctx context.Context, profile
 			}
 		}
 
-		// Scrape llama.cpp metrics from the pod.
-		endpoint := fmt.Sprintf("http://%s:8080/metrics", pod.Status.PodIP)
-		im, err := scraper.ScrapeLlamaCPP(ctx, r.ScrapeClient, endpoint)
+		// Dispatch to llama.cpp or vLLM based on pod annotations/labels.
+		backend := scraper.ResolveBackend(pod.Annotations, pod.Labels)
+		port := scraper.ResolveMetricsPort(backend, pod.Annotations, pod.Labels)
+		endpoint := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, port)
+		im, err := scraper.Scrape(ctx, r.ScrapeClient, backend, endpoint)
 		if err != nil {
-			log.Error(err, "failed to scrape inference pod", "pod", pod.Name)
+			log.Error(err, "failed to scrape inference pod", "pod", pod.Name, "backend", backend)
 			continue
 		}
 		im.Pod = pod.Name

--- a/internal/controller/usagereport_controller.go
+++ b/internal/controller/usagereport_controller.go
@@ -194,10 +194,12 @@ func (r *UsageReportReconciler) scrapeTokens(ctx context.Context, report *finops
 		if !podIsScrapeable(pod, nsFilter) {
 			continue
 		}
-		endpoint := fmt.Sprintf("http://%s:8080/metrics", pod.Status.PodIP)
-		im, err := scraper.ScrapeLlamaCPP(ctx, r.ScrapeClient, endpoint)
+		backend := scraper.ResolveBackend(pod.Annotations, pod.Labels)
+		port := scraper.ResolveMetricsPort(backend, pod.Annotations, pod.Labels)
+		endpoint := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, port)
+		im, err := scraper.Scrape(ctx, r.ScrapeClient, backend, endpoint)
 		if err != nil {
-			log.Error(err, "failed to scrape inference pod", "pod", pod.Name, "namespace", pod.Namespace)
+			log.Error(err, "failed to scrape inference pod", "pod", pod.Name, "namespace", pod.Namespace, "backend", backend)
 			continue
 		}
 		modelName := pod.Labels[modelLabel]

--- a/internal/scraper/backend.go
+++ b/internal/scraper/backend.go
@@ -1,0 +1,103 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+)
+
+// Backend identifies an inference runtime whose /metrics endpoint the scraper
+// knows how to parse.
+type Backend string
+
+const (
+	// BackendLlamaCPP scrapes metrics named llamacpp:*. Default when no
+	// backend annotation or label is present on the pod.
+	BackendLlamaCPP Backend = "llamacpp"
+	// BackendVLLM scrapes metrics named vllm:*.
+	BackendVLLM Backend = "vllm"
+)
+
+const (
+	// BackendAnnotation is the pod annotation or label key that selects the
+	// metrics backend. Values: "llamacpp" (default), "vllm".
+	BackendAnnotation = "infercost.ai/backend"
+	// MetricsPortAnnotation is the pod annotation or label key that overrides
+	// the default /metrics port. Defaults per backend:
+	//   llamacpp: 8080
+	//   vllm:     8000
+	MetricsPortAnnotation = "infercost.ai/metrics-port"
+)
+
+// DefaultPort returns the conventional /metrics port for a backend.
+func (b Backend) DefaultPort() int {
+	switch b {
+	case BackendVLLM:
+		return 8000
+	default:
+		return 8080
+	}
+}
+
+// ResolveBackend picks a backend from pod annotations or labels, falling back
+// to llama.cpp. Annotations take precedence over labels so users can override
+// the backend without relabeling pods that might be owned by a controller.
+func ResolveBackend(annotations, labels map[string]string) Backend {
+	if v, ok := annotations[BackendAnnotation]; ok {
+		return normalizeBackend(v)
+	}
+	if v, ok := labels[BackendAnnotation]; ok {
+		return normalizeBackend(v)
+	}
+	return BackendLlamaCPP
+}
+
+func normalizeBackend(v string) Backend {
+	switch Backend(v) {
+	case BackendVLLM:
+		return BackendVLLM
+	default:
+		return BackendLlamaCPP
+	}
+}
+
+// ResolveMetricsPort returns the /metrics port for a backend, honoring an
+// explicit infercost.ai/metrics-port annotation/label override when present.
+// Invalid or non-numeric overrides are ignored.
+func ResolveMetricsPort(backend Backend, annotations, labels map[string]string) int {
+	if v, ok := annotations[MetricsPortAnnotation]; ok {
+		if p, ok := parsePort(v); ok {
+			return p
+		}
+	}
+	if v, ok := labels[MetricsPortAnnotation]; ok {
+		if p, ok := parsePort(v); ok {
+			return p
+		}
+	}
+	return backend.DefaultPort()
+}
+
+func parsePort(s string) (int, bool) {
+	var p int
+	if _, err := fmt.Sscanf(s, "%d", &p); err != nil {
+		return 0, false
+	}
+	if p <= 0 || p > 65535 {
+		return 0, false
+	}
+	return p, true
+}
+
+// Scrape dispatches to the correct backend parser for an endpoint. Returns
+// a backend-agnostic InferenceMetrics so downstream code does not need to
+// know which runtime served the data.
+func Scrape(ctx context.Context, client *Client, backend Backend, endpoint string) (*InferenceMetrics, error) {
+	switch backend {
+	case BackendVLLM:
+		return ScrapeVLLM(ctx, client, endpoint)
+	case BackendLlamaCPP:
+		return ScrapeLlamaCPP(ctx, client, endpoint)
+	default:
+		return nil, fmt.Errorf("unknown backend %q", backend)
+	}
+}

--- a/internal/scraper/backend_test.go
+++ b/internal/scraper/backend_test.go
@@ -1,0 +1,109 @@
+package scraper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestResolveBackend_DefaultsToLlamaCPP(t *testing.T) {
+	b := ResolveBackend(nil, nil)
+	if b != BackendLlamaCPP {
+		t.Errorf("expected default llamacpp, got %q", b)
+	}
+}
+
+func TestResolveBackend_AnnotationBeatsLabel(t *testing.T) {
+	annotations := map[string]string{BackendAnnotation: "vllm"}
+	labels := map[string]string{BackendAnnotation: "llamacpp"}
+	if got := ResolveBackend(annotations, labels); got != BackendVLLM {
+		t.Errorf("annotation should win, got %q", got)
+	}
+}
+
+func TestResolveBackend_LabelFallback(t *testing.T) {
+	labels := map[string]string{BackendAnnotation: "vllm"}
+	if got := ResolveBackend(nil, labels); got != BackendVLLM {
+		t.Errorf("label fallback failed, got %q", got)
+	}
+}
+
+func TestResolveBackend_UnknownFallsBackToLlamaCPP(t *testing.T) {
+	annotations := map[string]string{BackendAnnotation: "sglang"}
+	if got := ResolveBackend(annotations, nil); got != BackendLlamaCPP {
+		t.Errorf("unknown backend should fall back to llamacpp, got %q", got)
+	}
+}
+
+func TestDefaultPort(t *testing.T) {
+	if BackendLlamaCPP.DefaultPort() != 8080 {
+		t.Errorf("llamacpp default port = %d, want 8080", BackendLlamaCPP.DefaultPort())
+	}
+	if BackendVLLM.DefaultPort() != 8000 {
+		t.Errorf("vllm default port = %d, want 8000", BackendVLLM.DefaultPort())
+	}
+}
+
+func TestResolveMetricsPort_Override(t *testing.T) {
+	annotations := map[string]string{MetricsPortAnnotation: "9090"}
+	if got := ResolveMetricsPort(BackendVLLM, annotations, nil); got != 9090 {
+		t.Errorf("annotation override = %d, want 9090", got)
+	}
+}
+
+func TestResolveMetricsPort_InvalidOverrideFallsBack(t *testing.T) {
+	annotations := map[string]string{MetricsPortAnnotation: "not-a-number"}
+	if got := ResolveMetricsPort(BackendVLLM, annotations, nil); got != 8000 {
+		t.Errorf("invalid override should fall back to default 8000, got %d", got)
+	}
+	annotations = map[string]string{MetricsPortAnnotation: "99999"}
+	if got := ResolveMetricsPort(BackendLlamaCPP, annotations, nil); got != 8080 {
+		t.Errorf("out-of-range override should fall back to default 8080, got %d", got)
+	}
+}
+
+func TestScrape_DispatchesToVLLM(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmMetricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := Scrape(context.Background(), client, BackendVLLM, server.URL)
+	if err != nil {
+		t.Fatalf("Scrape returned error: %v", err)
+	}
+	if m.PromptTokensTotal != 250000 {
+		t.Errorf("PromptTokensTotal = %v, want 250000 (vllm dispatch)", m.PromptTokensTotal)
+	}
+}
+
+func TestScrape_DispatchesToLlamaCPP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamacppMetricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := Scrape(context.Background(), client, BackendLlamaCPP, server.URL)
+	if err != nil {
+		t.Fatalf("Scrape returned error: %v", err)
+	}
+	if m.PromptTokensTotal != 107537 {
+		t.Errorf("PromptTokensTotal = %v, want 107537 (llamacpp dispatch)", m.PromptTokensTotal)
+	}
+}
+
+func TestScrape_UnknownBackendErrors(t *testing.T) {
+	client := NewClient(5 * time.Second)
+	_, err := Scrape(context.Background(), client, Backend("unknown"), "http://example.invalid")
+	if err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+}

--- a/internal/scraper/vllm.go
+++ b/internal/scraper/vllm.go
@@ -1,0 +1,56 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// VLLMPromptTokensMetric is the cumulative prompt (input) token counter.
+	VLLMPromptTokensMetric = "vllm:prompt_tokens_total"
+	// VLLMGenerationTokensMetric is the cumulative generated (output) token counter.
+	VLLMGenerationTokensMetric = "vllm:generation_tokens_total"
+	// VLLMRequestsRunningMetric is the number of in-flight requests.
+	VLLMRequestsRunningMetric = "vllm:num_requests_running"
+	// VLLMRequestsWaitingMetric is the number of queued requests waiting for a slot.
+	VLLMRequestsWaitingMetric = "vllm:num_requests_waiting"
+	// VLLMAvgGenerationThroughputMetric is the average generation throughput
+	// in tokens/sec. This metric is exposed directly by older vLLM versions;
+	// newer versions derive it from per-request histograms. The scraper reads
+	// it if present and leaves PredictedTokensPerSec at zero otherwise.
+	VLLMAvgGenerationThroughputMetric = "vllm:avg_generation_throughput_toks_per_s"
+	// VLLMAvgPromptThroughputMetric is the average prompt throughput in tokens/sec,
+	// exposed by older vLLM versions.
+	VLLMAvgPromptThroughputMetric = "vllm:avg_prompt_throughput_toks_per_s"
+)
+
+// ScrapeVLLM fetches inference metrics from a vLLM /metrics endpoint.
+//
+// vLLM labels its metrics with model_name so a single pod may serve multiple
+// models; the scraper aggregates counters across all label sets it observes
+// so the returned InferenceMetrics reflects the whole pod. Gauges (requests
+// running/waiting, throughput) are summed for the same reason — a pod serving
+// two models has the combined in-flight request count.
+func ScrapeVLLM(ctx context.Context, client *Client, endpoint string) (*InferenceMetrics, error) {
+	samples, err := client.Scrape(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("scraping vllm: %w", err)
+	}
+
+	m := &InferenceMetrics{}
+	for _, s := range samples {
+		switch s.Name {
+		case VLLMPromptTokensMetric:
+			m.PromptTokensTotal += s.Value
+		case VLLMGenerationTokensMetric:
+			m.PredictedTokensTotal += s.Value
+		case VLLMRequestsRunningMetric:
+			m.RequestsProcessing += s.Value
+		case VLLMAvgPromptThroughputMetric:
+			m.PromptTokensPerSec += s.Value
+		case VLLMAvgGenerationThroughputMetric:
+			m.PredictedTokensPerSec += s.Value
+		}
+	}
+	return m, nil
+}

--- a/internal/scraper/vllm_test.go
+++ b/internal/scraper/vllm_test.go
@@ -1,0 +1,155 @@
+package scraper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// vllmMetricsText is a representative vLLM /metrics response with model_name
+// labels. Counters include tokens and request histograms; gauges include the
+// running/waiting request counts and (older-vllm) average throughputs.
+const vllmMetricsText = `# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_total counter
+vllm:prompt_tokens_total{model_name="qwen3-coder-30b"} 250000
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{model_name="qwen3-coder-30b"} 870000
+# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="qwen3-coder-30b"} 4
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="qwen3-coder-30b"} 1
+# HELP vllm:avg_prompt_throughput_toks_per_s Average prompt throughput in tokens/s.
+# TYPE vllm:avg_prompt_throughput_toks_per_s gauge
+vllm:avg_prompt_throughput_toks_per_s{model_name="qwen3-coder-30b"} 1200.5
+# HELP vllm:avg_generation_throughput_toks_per_s Average generation throughput in tokens/s.
+# TYPE vllm:avg_generation_throughput_toks_per_s gauge
+vllm:avg_generation_throughput_toks_per_s{model_name="qwen3-coder-30b"} 42.8
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 37
+`
+
+func TestScrapeVLLM(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmMetricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := ScrapeVLLM(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeVLLM returned error: %v", err)
+	}
+
+	if m.PromptTokensTotal != 250000 {
+		t.Errorf("PromptTokensTotal = %v, want 250000", m.PromptTokensTotal)
+	}
+	if m.PredictedTokensTotal != 870000 {
+		t.Errorf("PredictedTokensTotal = %v, want 870000", m.PredictedTokensTotal)
+	}
+	if m.RequestsProcessing != 4 {
+		t.Errorf("RequestsProcessing = %v, want 4", m.RequestsProcessing)
+	}
+	if m.PromptTokensPerSec != 1200.5 {
+		t.Errorf("PromptTokensPerSec = %v, want 1200.5", m.PromptTokensPerSec)
+	}
+	if m.PredictedTokensPerSec != 42.8 {
+		t.Errorf("PredictedTokensPerSec = %v, want 42.8", m.PredictedTokensPerSec)
+	}
+}
+
+// A vLLM pod serving multiple models emits the same metric under different
+// model_name label sets. The scraper sums them because downstream attribution
+// is per-pod (not per-model-name-label), and the pod-level total is the figure
+// that matches what the controller records in UsageReport byModel breakdowns.
+func TestScrapeVLLM_AggregatesAcrossModelNameLabels(t *testing.T) {
+	multiModelMetrics := `# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_total counter
+vllm:prompt_tokens_total{model_name="qwen3-coder-30b"} 100000
+vllm:prompt_tokens_total{model_name="qwen3-8b"} 50000
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{model_name="qwen3-coder-30b"} 400000
+vllm:generation_tokens_total{model_name="qwen3-8b"} 200000
+`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(multiModelMetrics))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := ScrapeVLLM(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeVLLM returned error: %v", err)
+	}
+	if m.PromptTokensTotal != 150000 {
+		t.Errorf("PromptTokensTotal = %v, want 150000 (100k+50k)", m.PromptTokensTotal)
+	}
+	if m.PredictedTokensTotal != 600000 {
+		t.Errorf("PredictedTokensTotal = %v, want 600000 (400k+200k)", m.PredictedTokensTotal)
+	}
+}
+
+func TestScrapeVLLM_EmptyMetrics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := ScrapeVLLM(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeVLLM returned error: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil InferenceMetrics for empty response")
+	}
+	if m.PromptTokensTotal != 0 || m.PredictedTokensTotal != 0 {
+		t.Errorf("expected zero token counters for empty metrics, got prompt=%v predicted=%v",
+			m.PromptTokensTotal, m.PredictedTokensTotal)
+	}
+}
+
+func TestScrapeVLLM_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	_, err := ScrapeVLLM(context.Background(), client, server.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500 response")
+	}
+}
+
+func TestScrapeVLLM_IgnoresLlamaCPPMetrics(t *testing.T) {
+	// Pod mislabeled as vllm but actually serving llama.cpp returns zeros,
+	// which is the correct fail-safe (no silent mis-attribution).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamacppMetricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	m, err := ScrapeVLLM(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeVLLM returned error: %v", err)
+	}
+	if m.PromptTokensTotal != 0 || m.PredictedTokensTotal != 0 {
+		t.Errorf("expected zero for llama.cpp metrics parsed as vllm, got prompt=%v predicted=%v",
+			m.PromptTokensTotal, m.PredictedTokensTotal)
+	}
+}


### PR DESCRIPTION
## Why

The README advertised multi-backend support but only llama.cpp was actually wired. vLLM is the dominant runtime in enterprise Kubernetes GPU deployments, so an install that can't attribute vLLM tokens is effectively a single-backend tool. This PR makes the multi-backend claim real.

## What changed

- **\`internal/scraper/vllm.go\`** — parser for \`vllm:prompt_tokens_total\`, \`vllm:generation_tokens_total\`, \`vllm:num_requests_running\`, \`vllm:num_requests_waiting\`, and the older \`vllm:avg_{prompt,generation}_throughput_toks_per_s\` gauges. Aggregates across \`model_name\` label sets so a multi-model vLLM pod rolls up to a single \`InferenceMetrics\` — matches how downstream attribution is pod-scoped.
- **\`internal/scraper/backend.go\`** — \`Backend\` type, \`ResolveBackend\` / \`ResolveMetricsPort\` helpers, and a \`Scrape()\` dispatcher. Annotations beat labels (users can override without relabeling controller-owned pods). Defaults preserve existing behavior (llama.cpp on 8080).
- **Both controllers** (\`CostProfileReconciler\`, \`UsageReportReconciler\`) now pick the backend per-pod instead of hardcoding \`ScrapeLlamaCPP\`, and honor an optional \`infercost.ai/metrics-port\` override.
- **README** documents the annotation contract with a vLLM example.

## Per-pod selection

| Annotation (or label) | Values | Default |
|----------------------|--------|---------|
| \`infercost.ai/backend\` | \`llamacpp\`, \`vllm\` | \`llamacpp\` |
| \`infercost.ai/metrics-port\` | any valid port | \`8080\` (llamacpp), \`8000\` (vllm) |

## Test coverage

- vLLM happy path, multi-model label aggregation, empty response, HTTP error
- Mis-labeled pods (llama.cpp metrics parsed as vllm → zeros, not silent misattribution)
- Backend resolution: default, annotation > label precedence, label fallback, unknown → llama.cpp
- Port resolution: default, override, invalid override (non-numeric and out-of-range) falls back safely
- End-to-end dispatch through \`Scrape()\` for both backends

\`\`\`
$ go test ./... -count=1
ok  github.com/defilantech/infercost/internal/api          0.36s
ok  github.com/defilantech/infercost/internal/calculator   0.19s
ok  github.com/defilantech/infercost/internal/controller   5.90s
ok  github.com/defilantech/infercost/internal/scraper      0.63s
ok  github.com/defilantech/infercost/pkg/cli               1.01s
\`\`\`

## Out of scope (follow-ups)

- Histogram-derived throughput (newer vLLM exposes \`vllm:time_per_output_token_seconds\` buckets instead of the pre-computed gauge). The scraper reads the gauge today; histogram support will come with a broader expfmt change.
- Additional backends (SGLang, TGI, TensorRT-LLM) slot into the \`Backend\` type when needed.