### PR TITLE
docs: add CostProfile sample library for common GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ spec:
 kubectl apply -f costprofile.yaml
 ```
 
+> Don't want to write one from scratch? [`config/samples/costprofiles/`](config/samples/costprofiles/) ships ready-to-use manifests for H100, A100 80GB/40GB, L40S, A6000, RTX 4090/5090/5060 Ti, and Apple M2 Ultra — with pricing and amortization assumptions documented inline.
+
 ### See Your Costs
 
 ```bash

--- a/config/samples/costprofiles/README.md
+++ b/config/samples/costprofiles/README.md
@@ -1,0 +1,42 @@
+# CostProfile Sample Library
+
+Ready-to-use CostProfile manifests for the GPUs InferCost users ask about
+most often. Each file documents the pricing and amortization assumptions
+inline so you can adjust the numbers to your actual purchase.
+
+## How to use
+
+1. Pick the closest-fitting profile for your hardware.
+2. Edit `nodeSelector` to match your node (hostname, label, or pool selector).
+3. Adjust `purchasePriceUSD` to what you actually paid — list prices age fast.
+4. Set `ratePerKWh` to your real electricity cost — US avg is ~$0.12 but
+   commercial, industrial, and international rates vary widely.
+5. Pick `pueFactor`: `1.0` for homelabs/small racks, `1.2-1.4` for typical
+   enterprise data centers, `1.5+` for older facilities.
+6. `kubectl apply -f <file>`.
+
+## Files
+
+| File | GPU | Typical use |
+|------|-----|-------------|
+| [nvidia-h100-sxm5.yaml](nvidia-h100-sxm5.yaml) | H100 SXM5 80GB | Training + large-model inference |
+| [nvidia-a100-80gb.yaml](nvidia-a100-80gb.yaml) | A100 80GB | Large-model inference |
+| [nvidia-a100-40gb.yaml](nvidia-a100-40gb.yaml) | A100 40GB | Mid-model inference |
+| [nvidia-l40s.yaml](nvidia-l40s.yaml) | L40S 48GB | Inference-optimized enterprise |
+| [nvidia-a6000.yaml](nvidia-a6000.yaml) | RTX A6000 48GB | Prosumer inference |
+| [nvidia-rtx-4090.yaml](nvidia-rtx-4090.yaml) | RTX 4090 24GB | Consumer single-GPU |
+| [nvidia-rtx-5090.yaml](nvidia-rtx-5090.yaml) | RTX 5090 32GB | Consumer single-GPU, current gen |
+| [nvidia-rtx-5060-ti.yaml](nvidia-rtx-5060-ti.yaml) | RTX 5060 Ti 16GB | Hobbyist / lab single-GPU |
+| [apple-m2-ultra.yaml](apple-m2-ultra.yaml) | Apple M2 Ultra (Metal) | Mac Studio homelab |
+
+## Notes on the numbers
+
+- **Prices** are mid-2026 approximate list/street prices for reference.
+  Enterprise deals and bulk discounts can shift this dramatically.
+- **Amortization** is standardized at 3 years (data-center GPUs) or 4 years
+  (consumer/prosumer). This is a convention, not a rule — finance teams
+  often use 5 years for tax purposes.
+- **Maintenance** is set to 5% (consumer) or 10% (enterprise) of purchase
+  price per year. Real numbers depend on support contracts.
+- **TDP** values come from the manufacturer spec sheet. Use DCGM readings
+  for real-time power; TDP is the fallback when DCGM is unavailable.

--- a/config/samples/costprofiles/apple-m2-ultra.yaml
+++ b/config/samples/costprofiles/apple-m2-ultra.yaml
@@ -1,0 +1,26 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: apple-m2-ultra
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: apple
+    gpu.infercost.ai/model: m2-ultra
+spec:
+  hardware:
+    # Apple Silicon has no DCGM exporter; InferCost falls back to TDP-based
+    # power estimation from the tdpWatts field. Real-time power metrics will
+    # require a Metal-aware exporter (tracked on the roadmap).
+    gpuModel: "Apple M2 Ultra"
+    gpuCount: 1                       # Unified SoC counts as one "GPU"
+    # Purchase price: Mac Studio M2 Ultra (192GB unified memory): ~$6,800 MSRP.
+    # The whole box is the GPU here — there is no discrete card to price.
+    purchasePriceUSD: 6800
+    amortizationYears: 5              # Macs typically run longer than x86 boxes
+    maintenancePercentPerYear: 0.02
+    tdpWatts: 295                     # M2 Ultra sustained system power draw
+  electricity:
+    ratePerKWh: 0.15
+    pueFactor: 1.0
+  nodeSelector:
+    kubernetes.io/hostname: macstudio-m2ultra

--- a/config/samples/costprofiles/nvidia-a100-40gb.yaml
+++ b/config/samples/costprofiles/nvidia-a100-40gb.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-a100-40gb
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: a100-40gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA A100 40GB"
+    gpuCount: 4
+    # Purchase price: ~$6,000-$9,000 per A100 40GB PCIe at mid-2026 secondary
+    # market. New A100 40GB is effectively EOL; used/refurb dominates.
+    purchasePriceUSD: 28000
+    amortizationYears: 3
+    maintenancePercentPerYear: 0.08
+    tdpWatts: 250                     # PCIe 40GB TDP
+  electricity:
+    ratePerKWh: 0.12
+    pueFactor: 1.4
+  nodeSelector:
+    kubernetes.io/hostname: a100-40g-node-01

--- a/config/samples/costprofiles/nvidia-a100-80gb.yaml
+++ b/config/samples/costprofiles/nvidia-a100-80gb.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-a100-80gb
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: a100-80gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA A100 80GB"
+    gpuCount: 4
+    # Purchase price: ~$10,000-$15,000 per A100 80GB PCIe at mid-2026 street.
+    # SXM4 systems command a premium. Refurbished A100s trend $8k-$11k.
+    purchasePriceUSD: 48000
+    amortizationYears: 3
+    maintenancePercentPerYear: 0.10
+    tdpWatts: 400                     # PCIe SKU TDP; SXM4 is 500W
+  electricity:
+    ratePerKWh: 0.12
+    pueFactor: 1.4
+  nodeSelector:
+    kubernetes.io/hostname: a100-node-01

--- a/config/samples/costprofiles/nvidia-a6000.yaml
+++ b/config/samples/costprofiles/nvidia-a6000.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-a6000
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: a6000-48gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA RTX A6000"
+    gpuCount: 2
+    # Purchase price: ~$4,500-$5,500 per RTX A6000 at mid-2026 street.
+    # Prosumer card, 48GB, popular for local LLM labs due to VRAM-per-dollar.
+    purchasePriceUSD: 9500
+    amortizationYears: 4              # Longer life typical on prosumer boards
+    maintenancePercentPerYear: 0.05
+    tdpWatts: 300
+  electricity:
+    ratePerKWh: 0.12
+    pueFactor: 1.2                    # Small office / single-rack typical
+  nodeSelector:
+    kubernetes.io/hostname: a6000-node-01

--- a/config/samples/costprofiles/nvidia-h100-sxm5.yaml
+++ b/config/samples/costprofiles/nvidia-h100-sxm5.yaml
@@ -1,0 +1,26 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-h100-sxm5
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: h100-sxm5-80gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA H100 SXM5"
+    gpuCount: 8                    # Adjust for your node layout
+    # Purchase price: ~$28,000-$35,000 per H100 SXM5 80GB at mid-2026 list.
+    # 8-GPU HGX H100 systems quoted at $240k-$300k retail depending on vendor.
+    purchasePriceUSD: 280000
+    amortizationYears: 3
+    maintenancePercentPerYear: 0.10   # 10% annual support contract typical
+    tdpWatts: 700                     # Per-GPU TDP spec
+  electricity:
+    ratePerKWh: 0.12                  # US commercial average; colo/industrial varies
+    pueFactor: 1.4                    # Typical modern data center PUE
+  nodeSelector:
+    # Match the node where your H100 workloads run. Common options:
+    #   kubernetes.io/hostname: <node-name>
+    #   nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+    kubernetes.io/hostname: h100-node-01

--- a/config/samples/costprofiles/nvidia-l40s.yaml
+++ b/config/samples/costprofiles/nvidia-l40s.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-l40s
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: l40s-48gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA L40S"
+    gpuCount: 4
+    # Purchase price: ~$7,500-$9,000 per L40S at mid-2026 list.
+    # Inference-focused enterprise card with strong price/perf on LLM serving.
+    purchasePriceUSD: 32000
+    amortizationYears: 3
+    maintenancePercentPerYear: 0.10
+    tdpWatts: 350
+  electricity:
+    ratePerKWh: 0.12
+    pueFactor: 1.4
+  nodeSelector:
+    kubernetes.io/hostname: l40s-node-01

--- a/config/samples/costprofiles/nvidia-rtx-4090.yaml
+++ b/config/samples/costprofiles/nvidia-rtx-4090.yaml
@@ -1,0 +1,22 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-rtx-4090
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: rtx-4090-24gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA GeForce RTX 4090"
+    gpuCount: 2
+    # Purchase price: ~$1,800-$2,200 per 4090 at mid-2026 street (post-5090 depreciation).
+    purchasePriceUSD: 4000
+    amortizationYears: 4
+    maintenancePercentPerYear: 0.03
+    tdpWatts: 450
+  electricity:
+    ratePerKWh: 0.15                  # US residential typical
+    pueFactor: 1.0                    # Homelab / no dedicated cooling overhead
+  nodeSelector:
+    kubernetes.io/hostname: rtx4090-workstation

--- a/config/samples/costprofiles/nvidia-rtx-5060-ti.yaml
+++ b/config/samples/costprofiles/nvidia-rtx-5060-ti.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-rtx-5060-ti
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: rtx-5060-ti-16gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA GeForce RTX 5060 Ti"
+    gpuCount: 2
+    # Purchase price: ~$400-$480 per 5060 Ti 16GB at mid-2026 street.
+    # Entry-point for hobbyist local-LLM setups; pair for 32GB aggregate VRAM.
+    purchasePriceUSD: 960
+    amortizationYears: 4
+    maintenancePercentPerYear: 0.03
+    tdpWatts: 180
+  electricity:
+    ratePerKWh: 0.08                  # Low-cost regional / homelab
+    pueFactor: 1.0
+  nodeSelector:
+    kubernetes.io/hostname: lab-gpu-node

--- a/config/samples/costprofiles/nvidia-rtx-5090.yaml
+++ b/config/samples/costprofiles/nvidia-rtx-5090.yaml
@@ -1,0 +1,23 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-rtx-5090
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: rtx-5090-32gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA GeForce RTX 5090"
+    gpuCount: 1
+    # Purchase price: ~$2,000-$2,500 MSRP, street varies with availability.
+    # 32GB VRAM makes it the current consumer king for local LLM work.
+    purchasePriceUSD: 2200
+    amortizationYears: 4
+    maintenancePercentPerYear: 0.03
+    tdpWatts: 575
+  electricity:
+    ratePerKWh: 0.15
+    pueFactor: 1.0
+  nodeSelector:
+    kubernetes.io/hostname: rtx5090-workstation


### PR DESCRIPTION
## Why

Before this, authoring a CostProfile required guessing purchase prices, amortization windows, maintenance percentages, TDP watts, and PUE factors. The only example in the repo was a 2x RTX 5060 Ti setup that a data-center operator couldn't reasonably copy. This is a concrete adoption blocker — "how much is an H100 worth per hour in our rack?" is not a question a reader should have to Google.

## What's shipped

A sample library under \`config/samples/costprofiles/\` covering the GPUs users actually ask about:

| File | GPU | Typical use |
|------|-----|-------------|
| \`nvidia-h100-sxm5.yaml\` | H100 SXM5 80GB (8-GPU HGX) | Training + large-model inference |
| \`nvidia-a100-80gb.yaml\` | A100 80GB PCIe | Large-model inference |
| \`nvidia-a100-40gb.yaml\` | A100 40GB PCIe | Mid-model inference |
| \`nvidia-l40s.yaml\` | L40S 48GB | Inference-optimized enterprise |
| \`nvidia-a6000.yaml\` | RTX A6000 48GB | Prosumer inference |
| \`nvidia-rtx-5090.yaml\` | RTX 5090 32GB | Consumer single-GPU, current gen |
| \`nvidia-rtx-4090.yaml\` | RTX 4090 24GB | Consumer single-GPU, prior gen |
| \`nvidia-rtx-5060-ti.yaml\` | RTX 5060 Ti 16GB | Hobbyist / lab |
| \`apple-m2-ultra.yaml\` | Apple M2 Ultra (Metal) | Mac Studio homelab |

Each sample documents the pricing and amortization assumptions inline — mid-2026 street prices, standard 3-year enterprise / 4-year prosumer amortization, typical PUE by deployment class — so users can adjust to their own purchases without spelunking vendor quote sheets. A \`README.md\` in the samples dir explains how to adapt.

## Verification

All samples validated with \`kubectl --dry-run=client apply\` against the CRD schema.

## Follow-up

- Price refresh workflow (tracked separately): move to a dated \`lastVerified\` convention + PR template so the community can contribute updates without touching Go code.
- Metal power exporter (tracked separately): once ready, the Apple M2 Ultra sample becomes DCGM-free real-time instead of TDP fallback.