### PR TITLE
feat: surface DCGMReachable status condition on CostProfile

### DIFF
--- a/internal/controller/costprofile_controller.go
+++ b/internal/controller/costprofile_controller.go
@@ -45,6 +45,20 @@ const (
 	modelLabel = "inference.llmkube.dev/model"
 )
 
+// DCGM status reporting on CostProfile.status.conditions.
+const (
+	// ConditionDCGMReachable reports whether InferCost can read real-time GPU
+	// power metrics from a DCGM exporter. When False, the cost engine falls
+	// back to the TDP declared on the CostProfile spec — accurate enough for
+	// order-of-magnitude numbers, but it cannot track dynamic load.
+	ConditionDCGMReachable = "DCGMReachable"
+
+	ReasonDCGMHealthy       = "DCGMHealthy"
+	ReasonDCGMNotConfigured = "DCGMNotConfigured"
+	ReasonDCGMScrapeError   = "DCGMScrapeError"
+	ReasonDCGMNoReadings    = "DCGMNoReadings"
+)
+
 // CostProfileReconciler reconciles a CostProfile object.
 type CostProfileReconciler struct {
 	client.Client
@@ -84,32 +98,10 @@ func (r *CostProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		PUEFactor:                 profile.Spec.Electricity.PUEFactor,
 	}
 
-	// 2. Scrape DCGM for real-time GPU power draw.
-	var totalPowerW float64
-	if r.DCGMEndpoint != "" {
-		readings, err := scraper.ScrapeDCGM(ctx, r.ScrapeClient, r.DCGMEndpoint)
-		if err != nil {
-			log.Error(err, "failed to scrape DCGM, falling back to TDP")
-			totalPowerW = r.fallbackPowerDraw(profile)
-		} else {
-			// Filter readings to GPUs matching this profile's node selector.
-			node := profile.Spec.NodeSelector["kubernetes.io/hostname"]
-			for _, reading := range readings {
-				if node == "" || reading.Node == node {
-					totalPowerW += reading.PowerW
-
-					infercostmetrics.GPUPowerWatts.WithLabelValues(
-						profile.Name, reading.Node, reading.GPUID,
-					).Set(reading.PowerW)
-				}
-			}
-			if totalPowerW == 0 {
-				totalPowerW = r.fallbackPowerDraw(profile)
-			}
-		}
-	} else {
-		totalPowerW = r.fallbackPowerDraw(profile)
-	}
+	// 2. Scrape DCGM for real-time GPU power draw, and surface any fallback
+	// path as a DCGMReachable condition so operators can tell at a glance
+	// whether their dashboards will show real-time load or a flat TDP estimate.
+	totalPowerW, dcgmCondition := r.readDCGMPower(ctx, profile)
 
 	// 3. Compute hourly costs.
 	amort, elec, total := calculator.ComputeHourlyCost(hw, totalPowerW)
@@ -145,6 +137,8 @@ func (r *CostProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Message:            fmt.Sprintf("Hourly cost: $%.4f (amort: $%.4f, elec: $%.4f)", total, amort, elec),
 		LastTransitionTime: now,
 	})
+	dcgmCondition.LastTransitionTime = now
+	meta.SetStatusCondition(&profile.Status.Conditions, dcgmCondition)
 
 	if err := r.Status().Update(ctx, &profile); err != nil {
 		log.Error(err, "failed to update CostProfile status")
@@ -330,6 +324,69 @@ func (r *CostProfileReconciler) fallbackPowerDraw(profile finopsv1alpha1.CostPro
 		return float64(*profile.Spec.Hardware.TDPWatts) * float64(profile.Spec.Hardware.GPUCount)
 	}
 	return 0
+}
+
+// readDCGMPower returns the current total GPU power draw for the profile's
+// node selector along with a DCGMReachable condition that describes how the
+// number was obtained. Silent fallbacks are the main failure mode users have
+// reported ("why is my dashboard flat?"), so every path here produces an
+// explicit condition rather than hiding state.
+func (r *CostProfileReconciler) readDCGMPower(ctx context.Context, profile finopsv1alpha1.CostProfile) (float64, metav1.Condition) {
+	log := logf.FromContext(ctx)
+
+	if r.DCGMEndpoint == "" {
+		power := r.fallbackPowerDraw(profile)
+		return power, metav1.Condition{
+			Type:    ConditionDCGMReachable,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonDCGMNotConfigured,
+			Message: fmt.Sprintf("DCGM endpoint not set; using TDP fallback (%.0fW). Install the DCGM exporter for real-time power — see https://infercost.ai/docs/dcgm.", power),
+		}
+	}
+
+	readings, err := scraper.ScrapeDCGM(ctx, r.ScrapeClient, r.DCGMEndpoint)
+	if err != nil {
+		log.Error(err, "failed to scrape DCGM, falling back to TDP", "endpoint", r.DCGMEndpoint)
+		power := r.fallbackPowerDraw(profile)
+		return power, metav1.Condition{
+			Type:    ConditionDCGMReachable,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonDCGMScrapeError,
+			Message: fmt.Sprintf("DCGM scrape failed at %s: %v. Using TDP fallback (%.0fW).", r.DCGMEndpoint, err, power),
+		}
+	}
+
+	node := profile.Spec.NodeSelector["kubernetes.io/hostname"]
+	var totalPowerW float64
+	for _, reading := range readings {
+		if node == "" || reading.Node == node {
+			totalPowerW += reading.PowerW
+			infercostmetrics.GPUPowerWatts.WithLabelValues(
+				profile.Name, reading.Node, reading.GPUID,
+			).Set(reading.PowerW)
+		}
+	}
+
+	if totalPowerW == 0 {
+		power := r.fallbackPowerDraw(profile)
+		nodeDesc := node
+		if nodeDesc == "" {
+			nodeDesc = "(any node)"
+		}
+		return power, metav1.Condition{
+			Type:    ConditionDCGMReachable,
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonDCGMNoReadings,
+			Message: fmt.Sprintf("DCGM reachable at %s but returned no readings for node %q. Check the nodeSelector matches a GPU host. Using TDP fallback (%.0fW).", r.DCGMEndpoint, nodeDesc, power),
+		}
+	}
+
+	return totalPowerW, metav1.Condition{
+		Type:    ConditionDCGMReachable,
+		Status:  metav1.ConditionTrue,
+		Reason:  ReasonDCGMHealthy,
+		Message: fmt.Sprintf("DCGM healthy at %s (%.0fW current draw).", r.DCGMEndpoint, totalPowerW),
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/costprofile_dcgm_test.go
+++ b/internal/controller/costprofile_dcgm_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
+	"github.com/defilantech/infercost/internal/scraper"
+)
+
+func testProfile(tdp *int32) finopsv1alpha1.CostProfile {
+	return finopsv1alpha1.CostProfile{
+		Spec: finopsv1alpha1.CostProfileSpec{
+			Hardware: finopsv1alpha1.HardwareSpec{
+				GPUModel: "NVIDIA GeForce RTX 5060 Ti",
+				GPUCount: 2,
+				TDPWatts: tdp,
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": "shadowstack",
+			},
+		},
+	}
+}
+
+// readDCGMPower must tell the operator precisely why a number is what it is.
+// That's the whole point of this feature: no silent fallbacks, no "why is my
+// dashboard flat" mystery. Each test below pins one of the four return paths.
+
+func TestReadDCGMPower_EndpointNotConfigured(t *testing.T) {
+	tdp := int32(180)
+	r := &CostProfileReconciler{DCGMEndpoint: "", ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readDCGMPower(context.Background(), testProfile(&tdp))
+
+	if want := float64(360); power != want {
+		t.Errorf("power = %.0f, want %.0f (2x180 TDP)", power, want)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonDCGMNotConfigured {
+		t.Errorf("condition = %s/%s, want False/DCGMNotConfigured", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "TDP fallback") || !strings.Contains(cond.Message, "infercost.ai/docs/dcgm") {
+		t.Errorf("message missing guidance: %q", cond.Message)
+	}
+}
+
+func TestReadDCGMPower_EndpointUnreachable(t *testing.T) {
+	tdp := int32(180)
+	// Point at a port that's not listening. ScrapeDCGM must error quickly.
+	r := &CostProfileReconciler{DCGMEndpoint: "http://127.0.0.1:1/metrics", ScrapeClient: scraper.NewClient(500 * time.Millisecond)}
+
+	power, cond := r.readDCGMPower(context.Background(), testProfile(&tdp))
+
+	if want := float64(360); power != want {
+		t.Errorf("power = %.0f, want %.0f (TDP fallback)", power, want)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonDCGMScrapeError {
+		t.Errorf("condition = %s/%s, want False/DCGMScrapeError", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "DCGM scrape failed") {
+		t.Errorf("message should say scrape failed: %q", cond.Message)
+	}
+}
+
+func TestReadDCGMPower_NoReadingsForNode(t *testing.T) {
+	// DCGM returns readings, but none match the profile's node selector —
+	// the common "nodeSelector typo" failure mode.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`# HELP DCGM_FI_DEV_POWER_USAGE Power draw.
+# TYPE DCGM_FI_DEV_POWER_USAGE gauge
+DCGM_FI_DEV_POWER_USAGE{Hostname="other-node",gpu="0",UUID="GPU-xxx",modelName="RTX 4090",device="nvidia0"} 230
+`))
+	}))
+	defer server.Close()
+
+	tdp := int32(180)
+	r := &CostProfileReconciler{DCGMEndpoint: server.URL, ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readDCGMPower(context.Background(), testProfile(&tdp))
+
+	if want := float64(360); power != want {
+		t.Errorf("power = %.0f, want %.0f (TDP fallback when no node match)", power, want)
+	}
+	if cond.Status != metav1.ConditionUnknown || cond.Reason != ReasonDCGMNoReadings {
+		t.Errorf("condition = %s/%s, want Unknown/DCGMNoReadings", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "nodeSelector") {
+		t.Errorf("message should point at nodeSelector as likely cause: %q", cond.Message)
+	}
+}
+
+func TestReadDCGMPower_HealthyReadings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`# HELP DCGM_FI_DEV_POWER_USAGE Power draw.
+# TYPE DCGM_FI_DEV_POWER_USAGE gauge
+DCGM_FI_DEV_POWER_USAGE{Hostname="shadowstack",gpu="0",UUID="GPU-aaa",modelName="RTX 5060 Ti",device="nvidia0"} 140
+DCGM_FI_DEV_POWER_USAGE{Hostname="shadowstack",gpu="1",UUID="GPU-bbb",modelName="RTX 5060 Ti",device="nvidia1"} 120
+`))
+	}))
+	defer server.Close()
+
+	tdp := int32(180)
+	r := &CostProfileReconciler{DCGMEndpoint: server.URL, ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readDCGMPower(context.Background(), testProfile(&tdp))
+
+	if want := float64(260); power != want {
+		t.Errorf("power = %.0f, want %.0f (140+120 real-time)", power, want)
+	}
+	if cond.Status != metav1.ConditionTrue || cond.Reason != ReasonDCGMHealthy {
+		t.Errorf("condition = %s/%s, want True/DCGMHealthy", cond.Status, cond.Reason)
+	}
+}
+
+func TestReadDCGMPower_NoTDPAndNoDCGM(t *testing.T) {
+	// Worst case: no DCGM configured AND no TDP on the spec. Power is zero,
+	// but the condition still needs to spell out what's missing.
+	r := &CostProfileReconciler{DCGMEndpoint: "", ScrapeClient: scraper.NewClient(2 * time.Second)}
+	profile := finopsv1alpha1.CostProfile{
+		Spec: finopsv1alpha1.CostProfileSpec{
+			Hardware: finopsv1alpha1.HardwareSpec{GPUModel: "?", GPUCount: 1},
+		},
+	}
+
+	power, cond := r.readDCGMPower(context.Background(), profile)
+	if power != 0 {
+		t.Errorf("power = %.0f, want 0", power)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonDCGMNotConfigured {
+		t.Errorf("condition = %s/%s, want False/DCGMNotConfigured", cond.Status, cond.Reason)
+	}
+}


### PR DESCRIPTION
## Why

The cost engine has always fallen back to TDP-based power estimation when DCGM is missing or unreachable, but it did so silently — a user installing InferCost without the DCGM exporter (or with a typo in the node selector) sees a flat dashboard with no indication of why. \"Why is my dashboard flat?\" is the first-install support question InferCost should never need to answer.

## What changed

A \`DCGMReachable\` condition is now written on \`CostProfile.status.conditions\` every reconcile with one of four states:

| Status / Reason | Meaning |
|----------------|---------|
| \`True\` / \`DCGMHealthy\` | Real-time readings matched the node selector |
| \`Unknown\` / \`DCGMNoReadings\` | Scrape succeeded but no GPUs matched the selector — likely a nodeSelector typo. Falls back to TDP. |
| \`False\` / \`DCGMScrapeError\` | Endpoint set but unreachable. Falls back to TDP. |
| \`False\` / \`DCGMNotConfigured\` | No \`--dcgm-endpoint\` configured. Falls back to TDP. Message links to \`/docs/dcgm\`. |

Each message includes the numeric fallback value so operators can confirm at a glance whether the downstream cost is based on live or estimated power.

The DCGM logic is extracted from \`Reconcile\` into a new \`readDCGMPower\` that returns \`(power, condition)\`; \`fallbackPowerDraw\` is untouched.

## Tests

Five unit tests pin each return path:

\`\`\`
$ go test ./internal/controller/... -run TestReadDCGMPower -v
=== RUN   TestReadDCGMPower_EndpointNotConfigured           PASS
=== RUN   TestReadDCGMPower_EndpointUnreachable             PASS
=== RUN   TestReadDCGMPower_NoReadingsForNode               PASS
=== RUN   TestReadDCGMPower_HealthyReadings                 PASS
=== RUN   TestReadDCGMPower_NoTDPAndNoDCGM                  PASS
\`\`\`

Including the degenerate case (no DCGM configured AND no TDP on spec): power is zero, but the condition still explicitly spells out what's missing.

## Follow-ups (not in this PR)

- A \`/docs/dcgm\` page explaining how to install the DCGM exporter on common clusters (tracked separately as part of the docs scaffold task).
- Surfacing the same condition in the CLI \`infercost status\` output.