### PR TITLE
docs: write launch runbooks (CNCF, OpenCost, HN/Reddit, FinOps) — not executed yet

### DIFF
--- a/docs/launch/README.md
+++ b/docs/launch/README.md
@@ -1,0 +1,36 @@
+# Launch playbooks
+
+This directory holds the step-by-step runbooks for the external-facing
+moves that turn InferCost from "open-source tool in public" into a known
+entity in the FinOps / Kubernetes ecosystem.
+
+**These are intentionally not executed yet.** The project is pre-v1. Shipping
+a half-baked CNCF Landscape entry or a speculative "we exist" comment on the
+OpenCost GitHub issue is worse than silence — we only get one first
+impression with each audience.
+
+The trigger for executing these runbooks is **v1.0.0 feature-complete**,
+defined as the point where a first-time user can install the Helm chart on a
+fresh GPU cluster and get accurate, attributable, FOCUS-aligned cost data
+without reading the source code. Until then, these documents exist so the
+moves are ready to execute in order the moment the product earns them.
+
+| Runbook | When to run |
+|---------|------------|
+| [cncf-landscape.md](cncf-landscape.md) | v1.0.0 shipped, at least one production deployment, docs site live |
+| [opencost-engagement.md](opencost-engagement.md) | Same trigger — these land together for compounding effect |
+| [hn-reddit-launch.md](hn-reddit-launch.md) | Same week as CNCF/OpenCost, 48h after to pick up the trail |
+| [finops-foundation.md](finops-foundation.md) | Month 2-3 post-launch, after ≥3 real deployments and a draft WG paper |
+
+## Triggering a launch
+
+Launches are a branch of work, not a spontaneous event. To execute:
+
+1. Verify the **v1 feature-complete checklist** at the top of each runbook.
+   If any item is unchecked, stop and fix it before posting anything public.
+2. Schedule all three posts (CNCF Landscape PR, OpenCost comment, HN/Reddit)
+   within a 72-hour window. They reinforce each other — spacing them out
+   hurts reach.
+3. Monitor the week after and reply to every comment within 24 hours.
+   Launches where the maintainer disappears get archived as "yet another
+   one-shot project."

--- a/docs/launch/cncf-landscape.md
+++ b/docs/launch/cncf-landscape.md
@@ -1,0 +1,136 @@
+# CNCF Landscape submission runbook
+
+**Status**: Prepared, not executed. Do not run until the v1 feature-complete
+checklist at the bottom is green.
+
+The [CNCF Landscape](https://landscape.cncf.io) is the cloud-native ecosystem
+map. Getting InferCost on it is the single highest-signal "this is a real
+project" move for the FinOps, Platform Engineering, and Kubernetes-tooling
+audiences. It is not a certification or an endorsement — it is a directory —
+but it is the directory operators consult when they are evaluating tools.
+Missing from the Landscape and someone asking "does this exist?" on Reddit
+lose to a one-line entry on the Landscape every time.
+
+## Why we are waiting
+
+The Landscape page for each entry renders publicly within a week of merge
+and is visible to anyone who clicks around the FinOps or Observability
+categories. If the linked README walks a prospective user into "no data"
+Grafana dashboards, half-working vLLM support, or a hardcoded pricing table
+with a six-month-old `lastVerified` date, that user files the project under
+"not serious yet" and does not come back. Once is enough.
+
+## What the submission is
+
+A YAML entry added to
+[cncf/landscape](https://github.com/cncf/landscape) under `landscape.yml` in
+the category best matching InferCost. FinOps is the natural home:
+
+```
+- category: Provisioning
+  subcategories:
+    - subcategory: Continuous Integration & Delivery     # wrong
+    - subcategory: FinOps                                # right
+```
+
+Full entry skeleton:
+
+```yaml
+- item:
+    name: InferCost
+    homepage_url: https://infercost.ai
+    logo: infercost.svg         # uploaded separately under hosted_logos/
+    repo_url: https://github.com/defilantech/infercost
+    description: >-
+      Kubernetes-native cost intelligence for on-premises AI inference —
+      computes true cost-per-token from hardware amortization, DCGM-reported
+      GPU power draw, and electricity rates, then compares against cloud
+      API pricing.
+    crunchbase: "" # none; independent project
+    open_source: true
+    twitter: "https://twitter.com/defilan"
+    extra:
+      annotations_issue: "" # optional tracking link
+      accepted: ""
+```
+
+The logo must be an SVG with a consistent viewBox; the Landscape renders at
+different sizes. InferCost's existing `docs/images/logo.svg` is the source.
+
+## Category choice
+
+FinOps is right. InferCost is not OpenCost (infrastructure cost allocation)
+and not a generic observability tool — the product is specifically about the
+economics of a specific workload class (AI inference). The FinOps
+subcategory is sparsely populated, which is good: InferCost shows up alongside
+OpenCost, Kubecost, and the smaller FinOps tools, not buried in the 400-item
+Monitoring subcategory.
+
+## Step-by-step
+
+1. **Fork `cncf/landscape`** to the personal GitHub account that will sign
+   the PR.
+
+2. **Add the logo.** `hosted_logos/infercost.svg` — same file as
+   `docs/images/logo.svg` in the repo. Verify it renders in the Landscape
+   preview (there is a `make preview` in the landscape repo).
+
+3. **Edit `landscape.yml`.** Find the FinOps subcategory in the
+   `Provisioning` category. Add the entry from the skeleton above, preserving
+   alphabetical order within the subcategory.
+
+4. **Run the landscape repo's validation.** It catches common mistakes
+   (bad logo path, broken repo URL, missing fields):
+
+   ```bash
+   make check-missing
+   make validate-names
+   ```
+
+5. **Open a PR titled** `feat: add InferCost to FinOps subcategory`.
+   Body: one paragraph on what InferCost is, links to the live website and a
+   recent release, and a note on the team size (honest: solo maintainer with
+   active community).
+
+6. **Review cycle.** The CNCF Landscape maintainers typically respond within
+   a week. Expect at most one round of changes — usually about the
+   description length or a logo tweak.
+
+7. **Merge + post-merge verify.** Once merged, confirm the entry appears at
+   `landscape.cncf.io/card-mode?category=fin-ops` within 24 hours.
+
+## v1 feature-complete checklist (must be green before submitting)
+
+- [ ] Install story: `helm install` on a fresh GPU cluster → cost data in
+      Grafana within 5 minutes with no extra config
+- [ ] vLLM scraper shipping in the chart, tested against a real vLLM pod
+- [ ] `DCGMReachable` condition surfaces on CostProfile in every failure
+      mode (PR #28 landed)
+- [ ] FOCUS export produces a valid CSV importable into Kubecost or a
+      FinOps BI tool without transformation
+- [ ] Cloud pricing `lastVerified` is no older than 30 days
+- [ ] Documentation site live at infercost.ai/docs with Quickstart, CRD
+      reference, Troubleshooting, FAQ
+- [ ] Launch blog post published at infercost.ai/blog
+- [ ] At least one non-founder production deployment referenceable
+      (anonymized if needed)
+- [ ] GitHub repo: no open `bug` issues from the initial release, CI
+      consistently green on main
+- [ ] README under 600 lines, with a screenshot of the Grafana dashboard
+      showing real data
+
+## Why the bar is this high
+
+The Landscape entry is a promise that what the prospective user will
+experience matches the description. "Kubernetes-native cost intelligence"
+sets the expectation of a cohesive product, not a starter kit. A prospect
+who installs and hits rough edges within 5 minutes will downgrade not just
+their opinion of InferCost but their willingness to trust anything they find
+through the CNCF Landscape.
+
+## Timing
+
+Submit on a **Monday or Tuesday**. CNCF reviewers process PRs during the
+working week; weekend submissions sit for days. Announce the merged entry on
+LinkedIn and X the same day it goes live — the Landscape URL is the most
+credible link we can share.

--- a/docs/launch/finops-foundation.md
+++ b/docs/launch/finops-foundation.md
@@ -1,0 +1,123 @@
+# FinOps Foundation engagement runbook
+
+**Status**: Prepared, not executed. Expected execution window: month 2-3
+after v1 launch, once we have ≥3 real deployments and a draft working-group
+paper.
+
+## What we want from the FinOps Foundation
+
+Not a membership for its own sake. The specific goals, in order:
+
+1. **Legitimacy with finance teams.** A CTO evaluating InferCost hears
+   "FinOps Foundation" and it moves the tool from "open-source side
+   project" to "aligned with the standards body the CFO's team knows
+   about." That matters in enterprise sales conversations even when we
+   aren't selling anything.
+
+2. **FOCUS spec contribution.** The FOCUS specification explicitly scopes
+   out on-premises inference economics. InferCost is one of the few
+   working implementations of a FOCUS-compatible on-prem schema. There is
+   a concrete contribution to make in the AI working group.
+
+3. **AI FinOps working group.** It is forming now. Being a contributor
+   from day one beats being a latecomer. The working group produces the
+   thought-leadership papers that FinOps Certified Practitioners read.
+
+## Why we are waiting
+
+Two reasons:
+
+- **Joining as a pitch is different from joining as a contributor.**
+  Walking in with "we built a tool" gets us a polite Slack welcome. Walking
+  in with a 15-page draft WG paper titled "On-Premises LLM Inference Cost
+  Attribution: Schema, Implementation, and FOCUS Alignment" gets us a
+  working-group seat and co-authorship credit on the AI FinOps paper the
+  foundation will publish.
+
+- **Membership without deployment references is hollow.** The first
+  question at any WG meeting is "who is running this in production?" We
+  need at least three referenceable deployments — AFI (if the disclosure
+  is approved), plus two external adopters — before we can answer that
+  question credibly.
+
+## Pre-execution checklist
+
+- [ ] v1.0 released and on CNCF Landscape
+- [ ] AT LEAST three production deployments (named or anonymized with
+      FinOps-leadership sign-off)
+- [ ] Working-group paper draft: 10-15 pages, PDF, addresses
+      - On-prem inference economics: why it is different from general
+        cloud FinOps
+      - A proposed schema extension for FOCUS (the `x-Infer*` columns
+        we already ship)
+      - A reference implementation (InferCost) with a deployment
+        architecture diagram
+      - At least one worked example with real numbers
+- [ ] FOCUS-compatible export verified against the current FOCUS spec
+      version (not an old draft)
+
+## Membership tier
+
+**General membership** is the right tier when we engage. It gives
+working-group participation and voting rights on paper adoption. We do
+not need FinOps Certified Platform status yet — that is a larger lift
+(paid audit, feature-gating requirements) and makes sense only once the
+enterprise tier ships with multi-cluster aggregation, audit export, and
+SLA support.
+
+Target escalation:
+- **Month 3 post-launch**: General membership + submit WG paper
+- **Month 9 post-launch**: WG paper accepted / published
+- **Month 15-18**: Consider FinOps Certified Platform audit
+
+## Working-group paper: target outline
+
+```
+1. Scope: On-prem inference economics (what FOCUS v1 does not cover)
+2. Why the gap exists
+   - GPU allocation ≠ token allocation
+   - Hardware amortization changes per-token cost over time
+   - Electricity is a dimension FOCUS does not model
+3. Proposed schema
+   - x-InferGpuModel, x-InferGpuCount
+   - x-InferTokensInput, x-InferTokensOutput
+   - x-InferPowerKWh, x-InferPUEFactor, x-InferAmortizationMonths
+4. Reference implementation: InferCost
+   - CostProfile, UsageReport CRDs
+   - DCGM + llama.cpp/vLLM data flow
+   - FOCUS CSV export semantics
+5. Worked example
+   - 2x RTX 5060 Ti, 30-day period, ~50M tokens
+   - Cost breakdown: amortization, electricity, per-token, per-namespace
+   - Cloud equivalent comparison (list prices, with caveats)
+6. Recommendations for FOCUS v1.x
+   - Adopt x-Infer* as a standard extension for on-prem inference
+   - Align with OpenTelemetry GenAI semantic conventions
+7. Limitations and open questions
+   - Multi-tenant attribution when pods share GPUs
+   - Apple Silicon power telemetry
+   - Batch discount modeling in cloud comparisons
+```
+
+## Who to reach out to (not now — when executing)
+
+Research target contacts closer to execution. The FinOps Foundation roster
+rotates; any names written here would be stale by month 3. When the time
+comes:
+- Identify current WG chairs via FinOps Foundation website
+- Check who has recently published on AI/ML costs
+- Message through the foundation's Slack or official contact form, not
+  cold LinkedIn
+
+## What NOT to do
+
+- **Do not pay for individual practitioner certification** before the
+  tool is deployed. The cert is personal, not organizational, and the
+  study effort is real. If it is useful, it is useful at month 6+.
+- **Do not speak for the foundation** in any public forum. "FinOps
+  Foundation member" ≠ "FinOps Foundation spokesperson." Getting this
+  wrong burns the relationship.
+- **Do not publicly announce membership before the working-group paper
+  is submitted.** The announcement with "we just joined" is less
+  interesting than the announcement with "we just published a paper with
+  the FinOps Foundation."

--- a/docs/launch/hn-reddit-launch.md
+++ b/docs/launch/hn-reddit-launch.md
@@ -1,0 +1,150 @@
+# Hacker News + Reddit launch runbook
+
+**Status**: Prepared, not executed. Do not post until both the CNCF
+Landscape and OpenCost runbooks are complete.
+
+## Order of posts (72-hour window)
+
+1. **Day 1, Tuesday 9:00 AM ET** — Hacker News "Show HN"
+2. **Day 1, Tuesday 11:00 AM ET** — Reddit r/kubernetes
+3. **Day 2, Wednesday 9:00 AM ET** — Reddit r/LocalLLaMA
+
+Never post the same day to multiple venues. Cross-promotion reads as spam.
+Stagger, and reply to every comment.
+
+## Show HN
+
+**Title**: `Show HN: InferCost – True cost-per-token for on-prem AI inference`
+
+Hacker News titles: 80 chars max, no emoji, no exclamation points, no
+marketing superlatives ("great", "revolutionary", "best"). The `Show HN:`
+prefix is a specific convention — it signals "I built this and you can
+use/run it now."
+
+**URL**: https://infercost.ai (not the GitHub repo — the HN community
+penalizes repo-link submissions)
+
+**First comment** (post immediately after submitting):
+
+```
+Maintainer here. Background: we built this because the cloud-API FinOps
+tools treat on-prem GPU workloads as $0 cost, and OpenCost/Kubecost track
+GPU-hours but not tokens. Neither answered "what does it actually cost to
+run our model?"
+
+InferCost installs via Helm, reads DCGM for real-time GPU power, reads
+llama.cpp or vLLM /metrics for token counts, computes
+(amortization + electricity * power * PUE) / tokens, and writes the result
+to Prometheus + a CRD you can query with kubectl.
+
+The cloud comparison is honest — when cloud is cheaper at your
+utilization, the tool says so. No rigged numbers.
+
+Repo: https://github.com/defilantech/infercost
+Docs: https://infercost.ai/docs
+
+Happy to answer anything — about the math, the schema, or why we went
+CRDs instead of a SaaS dashboard.
+```
+
+## r/kubernetes
+
+**Title**: `InferCost – a Kubernetes operator that computes true cost-per-token for on-prem GPU inference workloads`
+
+Subreddit rules require the post be self-contained and not just a
+repo-dump. The body below is the full content — no external link-only
+post.
+
+```
+I built a Kubernetes operator that answers a question I kept hitting at
+work: what is our actual per-token cost when we run Llama or Qwen on our
+own GPUs? The standard FinOps tools (Kubecost, OpenCost) track
+GPU-hours but don't understand tokens. The AI observability tools
+(Langfuse, LiteLLM) track tokens but set on-prem infra cost to zero.
+
+InferCost combines them. Two CRDs (`CostProfile` declaring your hardware
+economics, `UsageReport` auto-computed), a controller pod, and a
+pre-built Grafana dashboard.
+
+The math:
+  cost_per_token = (GPU_amortization + electricity * power_draw * PUE)
+                   / tokens_per_hour
+
+Power draw comes from DCGM (real-time), tokens come from
+llama.cpp/vLLM /metrics. Cloud comparison uses a versioned YAML catalog
+of list prices you can override via ConfigMap for negotiated rates.
+
+Repo: https://github.com/defilantech/infercost
+Helm: `helm repo add infercost https://defilantech.github.io/infercost`
+Docs: https://infercost.ai/docs
+
+Apache 2.0, solo maintainer so far, using it myself on a 2x RTX 5060 Ti
+lab cluster. Feedback welcome — especially from anyone running vLLM in
+a multi-tenant setup.
+```
+
+## r/LocalLLaMA
+
+**Title**: `I tracked the actual cost of running Qwen3 on my home lab vs paying Claude/GPT API – here's the receipt`
+
+LocalLLaMA loves receipts and specific numbers. The title is deliberately
+personal (my lab, my numbers) — the "corporate pitch" vibe flops there.
+
+```
+Ran Qwen3-Coder-30B on my 2x RTX 5060 Ti setup for a week, ran the same
+prompts through my InferCost controller, and compared against what
+Anthropic + OpenAI would have charged. Screenshots of the Grafana
+dashboard in the post.
+
+Hardware amortization: $960 / 4 years / 2920 nights = $0.08/night
+Electricity: 260W sustained @ $0.08/kWh * 8hr/night = $0.17/night
+Total: ~$0.25 to generate 1.8M tokens overnight.
+
+Claude Sonnet 4.6 for the same tokens: $31.50.
+GPT-5.4: $24.00.
+
+That's the raw number. It does NOT mean "local always wins" — at low
+utilization the API wins and InferCost's honest comparison will show
+that. But for batch/overnight agentic workloads, the crossover point is
+pretty low.
+
+The tool:
+- GitHub: https://github.com/defilantech/infercost
+- Apache 2.0, runs on any K8s cluster with DCGM installed
+- Scrapes llama.cpp or vLLM /metrics
+- Ships a Grafana dashboard and a FOCUS-compatible CSV export
+
+Not trying to sell anything. Happy to share the raw CSV if someone
+wants to sanity-check my math.
+```
+
+## Common pitfalls
+
+- **Do not reply defensively.** HN and r/kubernetes both have skeptical
+  cultures. "That's a good point — here is the math" beats "actually
+  you're wrong" every time.
+- **Do not rate-limit yourself.** Reply to every serious comment within
+  2 hours for the first 12 hours, then within 24 hours. Dead threads
+  sink.
+- **Do not edit the post after the first hour.** On HN especially, edits
+  reset the age and signal desperation.
+- **Do not post to r/selfhosted, r/homelab, r/devops in the same week.**
+  Cross-posting to adjacent subs looks like spam even when the content
+  is good. Pick the two or three best venues and commit.
+
+## Metrics to watch
+
+- HN: front page = >30 upvotes in first 90 min. If it's <10 at 2 hours,
+  the post is dead — do not spam-refresh. Move on.
+- r/kubernetes: 50 upvotes / 20 comments in 24h is a solid post.
+- r/LocalLLaMA: screenshots and cost receipts get disproportionately
+  strong engagement here. Target 100+ upvotes.
+- GitHub stars velocity for 7 days after each post. Expect 10-30 stars
+  from HN on a middle-tier day, 5-15 from each Reddit post.
+
+## Recovery plan if one post flops
+
+Sometimes HN just misses you on the day. That is not fatal. If the HN
+post gets <5 upvotes after 4 hours, do not repost — Show HN is one-shot.
+Instead lean harder into Reddit and LinkedIn, and try HN again in 6+
+months with a major release.

--- a/docs/launch/opencost-engagement.md
+++ b/docs/launch/opencost-engagement.md
@@ -1,0 +1,100 @@
+# OpenCost engagement runbook
+
+**Status**: Prepared, not executed. Do not post until CNCF Landscape PR is
+merged and at least one production deployment is referenceable.
+
+## The opportunity
+
+OpenCost issue [#3533](https://github.com/opencost/opencost/issues/3533)
+is an open request titled roughly "AI inference cost allocation." The
+OpenCost team has acknowledged it is out of scope for their roadmap but
+valuable. That issue has a small active audience of FinOps engineers who
+exactly match the InferCost early-adopter profile.
+
+The move is **not**: "hey we built this, check it out." That reads as
+hijacking an issue thread and gets flagged by maintainers (rightly).
+
+The move **is**: post a complementary-integration proposal that positions
+OpenCost + InferCost as a two-tool stack, not competitors, and demonstrates
+we have read their codebase and allocation API.
+
+## Why we are waiting
+
+A comment that proposes integration must reference an existing integration.
+Without a working OpenCost-allocation-API consumer in the InferCost code,
+the comment is aspirational and the OpenCost maintainers will politely
+ignore it.
+
+Execute this runbook **only when** InferCost can read OpenCost's
+`/allocation` API and use those allocations as its infrastructure-cost
+basis, enriching them with inference economics. This is a v1.1 feature,
+not v1.0 — it is complex enough to warrant a dedicated PR and design
+review against the OpenCost schema.
+
+## Pre-execution checklist
+
+- [ ] InferCost can consume the OpenCost allocation API and reconcile its
+      GPU-hour allocations against InferCost's CostProfile CRDs
+- [ ] An end-to-end test deploys OpenCost + InferCost side-by-side on
+      shadowstack and shows consistent GPU-hour numbers
+- [ ] A one-pager at `docs/integrations/opencost.md` describes the
+      integration, the schema mapping, and the configuration flags
+- [ ] InferCost v1 is live on CNCF Landscape (runbook above completed)
+
+## Comment template
+
+Post as a top-level comment on
+[opencost/opencost#3533](https://github.com/opencost/opencost/issues/3533).
+Keep it under 250 words — long comments get skimmed.
+
+```
+We built InferCost (https://infercost.ai, Apache 2.0) explicitly to
+complement OpenCost's infrastructure cost allocation with inference
+economics — the gap this issue identifies.
+
+Division of concerns as we see it:
+  - OpenCost: GPU-hour allocation, namespace/workload attribution,
+    cluster-wide cost accounting (which you already do well)
+  - InferCost: per-token economics, hardware amortization over those
+    allocated GPU-hours, cloud-API comparison, FOCUS export for AI
+    inference
+
+InferCost consumes OpenCost's /allocation API as the infrastructure-cost
+basis and writes per-token cost attribution back out via Prometheus
+metrics and a FOCUS-compatible CSV export. We documented the integration
+at infercost.ai/docs/integrations/opencost.
+
+We are not proposing OpenCost absorb this — the CRDs and calculations are
+specific enough to the AI workload class (token metrics, DCGM power,
+model-name attribution) that folding them into OpenCost's general-purpose
+model would likely hurt both tools. But if the OpenCost maintainers see
+value in pointing users here for the AI-inference piece, we'd welcome
+that, and we'd be happy to reciprocate from our side.
+
+Happy to answer questions or discuss schema alignment.
+```
+
+## What to avoid
+
+- **Do not link to a LinkedIn post.** FinOps engineers on GitHub are
+  allergic to social-media-style promotion on technical threads.
+- **Do not open a parallel PR on OpenCost.** The comment is the move.
+  Any PR would be a drive-by and unwelcome.
+- **Do not respond defensively** if someone questions the overlap. The
+  response is: "Fair question — here is how the scopes differ in the
+  actual code at X link." Link, don't argue.
+
+## What to do after posting
+
+- Star OpenCost. Follow a few of their maintainers on GitHub.
+- Reply to every comment on the thread within 24 hours. Dropped threads
+  are worse than silence.
+- If an OpenCost maintainer engages positively, invite a cross-link from
+  their integrations doc. Don't propose this unprompted.
+
+## Timing
+
+Post on a Tuesday or Wednesday. Monday is noise from weekend digest
+readers; Thursday/Friday loses the work-week attention window. Same week
+as CNCF Landscape merge and HN post — all three moves reinforce each
+other.


### PR DESCRIPTION
## Why

Launching to the external FinOps and Kubernetes-tooling ecosystem is a four-front move: CNCF Landscape, OpenCost engagement, HN/Reddit, FinOps Foundation. Each has one-shot dynamics — a lukewarm first impression with any of these audiences is hard to recover from.

This PR **writes the runbooks but does not execute them**. Execution is gated on v1.0 feature-complete — each runbook has its own readiness checklist.

## What's in

- \`docs/launch/README.md\` — index + trigger conditions for execution
- \`docs/launch/cncf-landscape.md\` — exact YAML entry, category choice (FinOps subcategory), validation commands, and a v1-readiness checklist
- \`docs/launch/opencost-engagement.md\` — complementary-integration comment template for opencost/opencost#3533, explicitly gated on actually shipping an OpenCost-allocation-API consumer
- \`docs/launch/hn-reddit-launch.md\` — Show HN + r/kubernetes + r/LocalLLaMA, with venue-specific copy and a 72-hour stagger schedule
- \`docs/launch/finops-foundation.md\` — General membership via a draft WG paper, targeting co-authorship on the AI FinOps paper rather than a cold pitch

## Why not submit now

Walking into any of these with "we built a tool, check it out" loses to silence. The runbooks say this explicitly so future-us does not talk ourselves into premature submission on an energetic Saturday.

## Not blocking anything

These are pure docs. No code, no CI impact, mergeable any time. Happy to rebase if other PRs land first.