### PR TITLE
feat: FOCUS-compatible CSV export for UsageReport data

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ token_cost = (GPU_amortization + electricity x power_draw x PUE) / tokens_per_ho
 - **Per-team attribution**: Costs broken down by Kubernetes namespace with zero configuration
 - **Prometheus metrics**: 12 gauges scrapeable by any monitoring tool, not locked to Grafana
 - **REST API**: Programmatic access to cost data for custom dashboards, bots, and integrations
-- **CLI**: `infercost status` and `infercost compare` for terminal-based cost analysis
+- **CLI**: `infercost status`, `infercost compare`, `infercost export focus` for terminal analysis and FOCUS-compatible CSV export
+- **FOCUS-compatible export**: Drop InferCost data into Kubecost, Cloudability, or any FOCUS-aware BI pipeline. See [docs/focus-export.md](docs/focus-export.md).
 - **Pre-built Grafana dashboard**: Ships as JSON, auto-provisionable via sidecar
 - **Multi-backend**: Scrapes llama.cpp, vLLM, or any Prometheus-compatible inference engine
 

--- a/docs/focus-export.md
+++ b/docs/focus-export.md
@@ -1,0 +1,136 @@
+# FOCUS-compatible CSV export
+
+InferCost exports UsageReport data as CSV that conforms to the [FOCUS
+specification](https://focus.finops.org/) (FinOps Open Cost and Usage
+Specification). Standard FOCUS v1 columns are populated so the export
+drops into any FOCUS-aware consumer (Kubecost, Cloudability, internal BI)
+without a custom importer. On-prem inference specifics — GPU model, token
+counts, power, cloud-equivalent cost — live in `x-Infer*` extension
+columns, which FOCUS explicitly allows for vendor-specific dimensions.
+
+## Why
+
+FOCUS v1 was designed around SaaS cloud billing. It has no column for
+"GPU amortization" or "tokens consumed" — the fields an on-prem AI FinOps
+program actually needs. Rather than invent a proprietary schema or fork
+FOCUS, InferCost follows the spec's extension convention (`x-` prefix)
+and populates the standard columns with the closest natural analogue.
+
+A finance team that already pipes OpenCost → Kubecost → their BI stack
+can add InferCost's CSV as another data source and slice the whole AI
+spend alongside cloud spend on the same dashboard.
+
+## Running the export
+
+CLI:
+
+```bash
+# All UsageReports in the cluster, to stdout
+infercost export focus
+
+# Scope to one namespace + write to a file
+infercost export focus --namespace engineering --out engineering-april.csv
+
+# Filter by period (matches UsageReport.status.period)
+infercost export focus --period 2026-04 --out april-2026.csv
+
+# Tag with a region for multi-cluster aggregation
+infercost export focus --region us-east-1-prod --out prod-cluster.csv
+```
+
+Pipe into standard tools:
+
+```bash
+# Only charges above $1
+infercost export focus | awk -F, 'NR==1 || $1+0 > 1.0'
+
+# Total spend by namespace
+infercost export focus --period 2026-04 | \
+  awk -F, 'NR>1 {by_ns[$29]+=$1} END {for (n in by_ns) print n, by_ns[n]}'
+```
+
+## Row shape
+
+One row per `(UsageReport, ModelCostBreakdown)`. A report with three
+models produces three rows; a report with no model breakdown (e.g.
+warming up, pods missing) produces one rollup row so the namespace still
+appears in finance exports.
+
+## Column reference
+
+### Standard FOCUS v1 columns
+
+| Column | Value | Notes |
+|--------|-------|-------|
+| `BilledCost` | Computed on-prem cost for the row | Same as EffectiveCost / ListCost / ContractedCost — no discount model on-prem |
+| `EffectiveCost` | Same as BilledCost | |
+| `ListCost` | Same as BilledCost | |
+| `ContractedCost` | Same as BilledCost | |
+| `ChargePeriodStart` | `UsageReport.status.periodStart` | RFC3339 |
+| `ChargePeriodEnd` | `UsageReport.status.periodEnd` | RFC3339 |
+| `BillingPeriodStart` | First of the month containing the charge | RFC3339 |
+| `BillingPeriodEnd` | First of the next month | RFC3339 |
+| `Currency` | `USD` | Always |
+| `ServiceName` | `On-Prem AI Inference` | |
+| `ServiceCategory` | `AI and Machine Learning` | FOCUS v1 canonical enum value |
+| `ProviderName` | `InferCost` | |
+| `PublisherName` | `Self-Hosted` | |
+| `InvoiceIssuerName` | `Self-Hosted` | |
+| `ResourceId` | `<ns>/<report>/<model>` (or `<ns>/<report>`) | Stable per row |
+| `ResourceName` | Model name (or report name for rollups) | |
+| `ResourceType` | `AI Inference Endpoint` | |
+| `Region` | `--region` flag value | Empty unless explicitly set |
+| `UsageQuantity` | Total tokens (input + output) | |
+| `UsageUnit` | `Tokens` | |
+| `PricingUnit` | `1M Tokens` | |
+| `PricingCategory` | `Usage-Based` | |
+| `ChargeCategory` | `Usage` | FOCUS v1 enum |
+| `ChargeClass` | empty | Non-empty would indicate a correction |
+| `ChargeDescription` | Human-readable summary of the charge | |
+| `ChargeFrequency` | `Usage-Based` | |
+| `SkuId` | Model name | |
+| `SkuPriceId` | Model name | |
+| `SubAccountId` | Kubernetes namespace | For per-team chargeback |
+| `SubAccountName` | Kubernetes namespace | |
+| `Tags` | JSON object with report/schedule/model/gpuModel | |
+
+### InferCost extension columns (`x-Infer*`)
+
+| Column | Value |
+|--------|-------|
+| `x-InferCostProfile` | Name of the CostProfile this row references |
+| `x-InferGpuModel` | GPU model declared on the profile |
+| `x-InferGpuCount` | Number of GPUs on the profile |
+| `x-InferTokensInput` | Input tokens for this row |
+| `x-InferTokensOutput` | Output tokens for this row |
+| `x-InferAmortizationYears` | Amortization window from the profile |
+| `x-InferElectricityRatePerKWh` | Rate from the profile |
+| `x-InferPUEFactor` | PUE from the profile |
+| `x-InferCloudEquivalentProvider` | Provider with highest savings vs on-prem |
+| `x-InferCloudEquivalentModel` | Model name in that provider |
+| `x-InferCloudEquivalentCostUSD` | What the tokens would have cost there |
+| `x-InferSavingsUSD` | CloudEquivalent − on-prem |
+| `x-InferSavingsPercent` | Savings as a percentage |
+
+The cloud-equivalent columns are populated from the highest-savings entry
+in `UsageReport.status.cloudComparison`. Consumers who need the full
+per-provider comparison should query the CRD directly — FOCUS is a flat
+export, not a query layer.
+
+## FOCUS version alignment
+
+InferCost tracks FOCUS v1.0. When FOCUS v1.1 lands with AI-inference
+coverage, `x-Infer*` columns will migrate to the standard names in a
+minor release with a documented column alias. Until then, the `x-Infer*`
+prefix guarantees import compatibility (FOCUS requires importers to
+tolerate unknown `x-` columns rather than reject them).
+
+## Importing into Kubecost / Cloudability
+
+Both tools accept FOCUS CSV via their custom-import flows. The standard
+columns are enough for high-level spend dashboards. To unlock per-token
+and per-GPU-model views, add the `x-Infer*` columns as custom fields.
+
+Open a GitHub issue if you hit a downstream tool that rejects a
+specific row — we will adjust the emission rather than tell users to
+work around it.

--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+*/
+
+// Package focus emits FOCUS-compatible CSV from InferCost UsageReport CRs.
+//
+// FOCUS (FinOps Open Cost and Usage Specification) is the emerging standard
+// the FinOps Foundation publishes for billing/usage data exchange. Its v1
+// schema explicitly scopes out on-premises inference economics — there is no
+// standard column for "GPU amortization" or "tokens consumed." InferCost
+// fills the gap with a set of x-Infer* extension columns while keeping the
+// standard columns populated so the CSV drops into any FOCUS-aware consumer
+// (Kubecost, Cloudability, internal BI) without a custom importer.
+//
+// Every row represents one charge — one (period, namespace, model) cell in
+// the cost grid. A single UsageReport typically expands to N rows, one per
+// ModelCostBreakdown. Reports with no model breakdown emit a single rollup
+// row so a misconfigured namespace still reports zero rather than
+// disappearing silently.
+package focus
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
+)
+
+// Columns is the full ordered column header emitted in every CSV. Order is
+// significant — downstream importers key off column position when they do
+// not fully parse the header.
+var Columns = []string{
+	// Standard FOCUS v1 columns
+	"BilledCost",
+	"EffectiveCost",
+	"ListCost",
+	"ContractedCost",
+	"ChargePeriodStart",
+	"ChargePeriodEnd",
+	"BillingPeriodStart",
+	"BillingPeriodEnd",
+	"Currency",
+	"ServiceName",
+	"ServiceCategory",
+	"ProviderName",
+	"PublisherName",
+	"InvoiceIssuerName",
+	"ResourceId",
+	"ResourceName",
+	"ResourceType",
+	"Region",
+	"UsageQuantity",
+	"UsageUnit",
+	"PricingUnit",
+	"PricingCategory",
+	"ChargeCategory",
+	"ChargeClass",
+	"ChargeDescription",
+	"ChargeFrequency",
+	"SkuId",
+	"SkuPriceId",
+	"SubAccountId",
+	"SubAccountName",
+	"Tags",
+	// InferCost extensions for on-prem inference (prefix per FOCUS spec)
+	"x-InferCostProfile",
+	"x-InferGpuModel",
+	"x-InferGpuCount",
+	"x-InferTokensInput",
+	"x-InferTokensOutput",
+	"x-InferAmortizationYears",
+	"x-InferElectricityRatePerKWh",
+	"x-InferPUEFactor",
+	"x-InferCloudEquivalentProvider",
+	"x-InferCloudEquivalentModel",
+	"x-InferCloudEquivalentCostUSD",
+	"x-InferSavingsUSD",
+	"x-InferSavingsPercent",
+}
+
+// ExportInput is everything needed to emit a FOCUS CSV from an InferCost
+// deployment. Reports and Profiles are fetched by the caller (CLI or API) so
+// this package has no k8s-client dependency and is trivial to unit-test.
+type ExportInput struct {
+	Reports  []finopsv1alpha1.UsageReport
+	Profiles map[string]finopsv1alpha1.CostProfile // keyed by name
+	Region   string                                // optional, maps to the FOCUS Region column
+}
+
+// Write emits FOCUS-compatible CSV for all reports in the input, one row per
+// model breakdown (or one rollup row when a report has no model data).
+func Write(w io.Writer, input ExportInput) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(Columns); err != nil {
+		return fmt.Errorf("writing header: %w", err)
+	}
+
+	// Deterministic ordering so goldens don't flake and finance can diff runs.
+	reports := make([]finopsv1alpha1.UsageReport, len(input.Reports))
+	copy(reports, input.Reports)
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].Namespace != reports[j].Namespace {
+			return reports[i].Namespace < reports[j].Namespace
+		}
+		return reports[i].Name < reports[j].Name
+	})
+
+	for _, r := range reports {
+		rows := rowsForReport(r, input)
+		for _, row := range rows {
+			if err := cw.Write(row); err != nil {
+				return fmt.Errorf("writing row: %w", err)
+			}
+		}
+	}
+
+	cw.Flush()
+	return cw.Error()
+}
+
+// rowsForReport expands a single UsageReport into FOCUS rows. If the report
+// has model-level breakdowns it emits one row per model+namespace; otherwise
+// one rollup row so the namespace still appears in finance exports.
+func rowsForReport(r finopsv1alpha1.UsageReport, input ExportInput) [][]string {
+	profile := input.Profiles[r.Spec.CostProfileRef]
+	best := bestCloudComparison(r.Status.CloudComparison)
+
+	if len(r.Status.ByModel) == 0 {
+		return [][]string{rowFromTotals(r, profile, input.Region, best)}
+	}
+
+	models := make([]finopsv1alpha1.ModelCostBreakdown, len(r.Status.ByModel))
+	copy(models, r.Status.ByModel)
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].Namespace != models[j].Namespace {
+			return models[i].Namespace < models[j].Namespace
+		}
+		return models[i].Model < models[j].Model
+	})
+
+	rows := make([][]string, 0, len(models))
+	for _, m := range models {
+		rows = append(rows, rowFromModel(r, m, profile, input.Region, best))
+	}
+	return rows
+}
+
+// rowFromModel builds one CSV row for a (UsageReport, ModelCostBreakdown).
+// The cloud comparison is per-report, not per-model, because UsageReport
+// doesn't carry per-model cloud numbers today — we attribute the same best
+// comparison to each row and note the period in ChargeDescription.
+func rowFromModel(
+	r finopsv1alpha1.UsageReport,
+	m finopsv1alpha1.ModelCostBreakdown,
+	profile finopsv1alpha1.CostProfile,
+	region string,
+	best *finopsv1alpha1.CloudComparisonEntry,
+) []string {
+	return buildRow(
+		m.EstimatedCostUSD,
+		periodStart(r), periodEnd(r),
+		m.InputTokens+m.OutputTokens,
+		fmt.Sprintf("%s/%s/%s", r.Namespace, r.Name, m.Model),
+		m.Model,
+		m.Namespace, m.Namespace,
+		fmt.Sprintf("Inference on %s for period %s", m.Model, r.Status.Period),
+		m.Model, // SkuId == model name
+		buildTags(r, m, profile),
+		profile, r.Spec.CostProfileRef, region,
+		m.InputTokens, m.OutputTokens,
+		best, m.EstimatedCostUSD,
+	)
+}
+
+// rowFromTotals is the rollup path when a report has no per-model breakdown.
+// This happens when inference is still warming up, pods are missing, or
+// scraping failed — we emit one row so finance sees the namespace anyway.
+func rowFromTotals(
+	r finopsv1alpha1.UsageReport,
+	profile finopsv1alpha1.CostProfile,
+	region string,
+	best *finopsv1alpha1.CloudComparisonEntry,
+) []string {
+	return buildRow(
+		r.Status.EstimatedCostUSD,
+		periodStart(r), periodEnd(r),
+		r.Status.InputTokens+r.Status.OutputTokens,
+		fmt.Sprintf("%s/%s", r.Namespace, r.Name),
+		r.Name,
+		r.Namespace, r.Namespace,
+		fmt.Sprintf("Inference rollup for period %s (no model breakdown)", r.Status.Period),
+		"", // no SkuId when no model
+		fmt.Sprintf("costProfile=%s", r.Spec.CostProfileRef),
+		profile, r.Spec.CostProfileRef, region,
+		r.Status.InputTokens, r.Status.OutputTokens,
+		best, r.Status.EstimatedCostUSD,
+	)
+}
+
+// buildRow centralizes the column order so the header and the rows never
+// drift. Adding a new column requires adding it here and in Columns.
+func buildRow(
+	cost float64,
+	start, end time.Time,
+	totalTokens int64,
+	resourceID, resourceName, subAccountID, subAccountName, chargeDesc, skuID, tags string,
+	profile finopsv1alpha1.CostProfile,
+	profileName, region string,
+	tokensIn, tokensOut int64,
+	best *finopsv1alpha1.CloudComparisonEntry,
+	onPremCost float64,
+) []string {
+	costStr := money(cost)
+	billingStart, billingEnd := monthBounds(start)
+
+	row := []string{
+		costStr,                            // BilledCost
+		costStr,                            // EffectiveCost — self-reported, same as billed
+		costStr,                            // ListCost — same; no discount model on-prem
+		costStr,                            // ContractedCost — same; self-reported
+		isoTime(start),                     // ChargePeriodStart
+		isoTime(end),                       // ChargePeriodEnd
+		isoTime(billingStart),              // BillingPeriodStart
+		isoTime(billingEnd),                // BillingPeriodEnd
+		"USD",                              // Currency
+		"On-Prem AI Inference",             // ServiceName
+		"AI and Machine Learning",          // ServiceCategory (FOCUS enum value)
+		"InferCost",                        // ProviderName
+		"Self-Hosted",                      // PublisherName — no third-party biller
+		"Self-Hosted",                      // InvoiceIssuerName
+		resourceID,                         // ResourceId
+		resourceName,                       // ResourceName
+		"AI Inference Endpoint",            // ResourceType
+		region,                             // Region — caller-supplied (e.g. node label)
+		strconv.FormatInt(totalTokens, 10), // UsageQuantity
+		"Tokens",                           // UsageUnit
+		"1M Tokens",                        // PricingUnit
+		"Usage-Based",                      // PricingCategory
+		"Usage",                            // ChargeCategory (FOCUS enum)
+		"",                                 // ChargeClass (empty = not a correction)
+		chargeDesc,                         // ChargeDescription
+		"Usage-Based",                      // ChargeFrequency
+		skuID,                              // SkuId
+		skuID,                              // SkuPriceId
+		subAccountID,                       // SubAccountId
+		subAccountName,                     // SubAccountName
+		tags,                               // Tags
+		// x-Infer* extensions
+		profileName,
+		profile.Spec.Hardware.GPUModel,
+		strconv.FormatInt(int64(profile.Spec.Hardware.GPUCount), 10),
+		strconv.FormatInt(tokensIn, 10),
+		strconv.FormatInt(tokensOut, 10),
+		strconv.FormatInt(int64(profile.Spec.Hardware.AmortizationYears), 10),
+		strconv.FormatFloat(profile.Spec.Electricity.RatePerKWh, 'f', -1, 64),
+		strconv.FormatFloat(profile.Spec.Electricity.PUEFactor, 'f', -1, 64),
+	}
+
+	if best != nil {
+		row = append(row,
+			best.Provider,
+			best.Model,
+			money(best.EstimatedCloudCostUSD),
+			money(best.EstimatedCloudCostUSD-onPremCost),
+			strconv.FormatFloat(best.SavingsPercent, 'f', 2, 64),
+		)
+	} else {
+		row = append(row, "", "", "", "", "")
+	}
+	return row
+}
+
+// bestCloudComparison picks the highest-savings comparison (the one that
+// makes on-prem look best) because that is the useful benchmark for a
+// finance audit trail — "what would it have cost us if we had gone cloud."
+// Consumers who need the full comparison matrix can reach into the
+// UsageReport CRD directly; FOCUS CSV is a flat export, not a query layer.
+func bestCloudComparison(entries []finopsv1alpha1.CloudComparisonEntry) *finopsv1alpha1.CloudComparisonEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	best := &entries[0]
+	for i := 1; i < len(entries); i++ {
+		if entries[i].SavingsUSD > best.SavingsUSD {
+			best = &entries[i]
+		}
+	}
+	return best
+}
+
+func buildTags(r finopsv1alpha1.UsageReport, m finopsv1alpha1.ModelCostBreakdown, profile finopsv1alpha1.CostProfile) string {
+	// FOCUS Tags is a JSON-object string in v1. Keep it minimal but useful:
+	// the dimensions an auditor would want to filter on.
+	return fmt.Sprintf(`{"report":"%s","schedule":"%s","model":"%s","gpuModel":"%s"}`,
+		r.Name, r.Spec.Schedule, m.Model, profile.Spec.Hardware.GPUModel)
+}
+
+func periodStart(r finopsv1alpha1.UsageReport) time.Time {
+	if r.Status.PeriodStart != nil {
+		return r.Status.PeriodStart.Time
+	}
+	return time.Time{}
+}
+
+func periodEnd(r finopsv1alpha1.UsageReport) time.Time {
+	if r.Status.PeriodEnd != nil {
+		return r.Status.PeriodEnd.Time
+	}
+	return time.Time{}
+}
+
+func monthBounds(t time.Time) (time.Time, time.Time) {
+	if t.IsZero() {
+		return t, t
+	}
+	start := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 1, 0)
+	return start, end
+}
+
+func isoTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func money(v float64) string {
+	return strconv.FormatFloat(v, 'f', 4, 64)
+}

--- a/internal/focus/focus_test.go
+++ b/internal/focus/focus_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright 2026.
+*/
+
+package focus
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
+)
+
+func sampleProfile() finopsv1alpha1.CostProfile {
+	return finopsv1alpha1.CostProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "shadowstack-5060ti"},
+		Spec: finopsv1alpha1.CostProfileSpec{
+			Hardware: finopsv1alpha1.HardwareSpec{
+				GPUModel:          "NVIDIA GeForce RTX 5060 Ti",
+				GPUCount:          2,
+				PurchasePriceUSD:  960,
+				AmortizationYears: 4,
+			},
+			Electricity: finopsv1alpha1.ElectricitySpec{
+				RatePerKWh: 0.08,
+				PUEFactor:  1.0,
+			},
+		},
+	}
+}
+
+func sampleReport() finopsv1alpha1.UsageReport {
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 20, 17, 0, 0, 0, time.UTC)
+	return finopsv1alpha1.UsageReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "engineering-daily",
+			Namespace: "engineering",
+		},
+		Spec: finopsv1alpha1.UsageReportSpec{
+			CostProfileRef: "shadowstack-5060ti",
+			Schedule:       finopsv1alpha1.ReportScheduleDaily,
+		},
+		Status: finopsv1alpha1.UsageReportStatus{
+			Period:           "2026-04",
+			PeriodStart:      &metav1.Time{Time: start},
+			PeriodEnd:        &metav1.Time{Time: end},
+			InputTokens:      1_200_000,
+			OutputTokens:     800_000,
+			EstimatedCostUSD: 0.8941,
+			ByModel: []finopsv1alpha1.ModelCostBreakdown{
+				{
+					Model:            "qwen3-coder-30b",
+					Namespace:        "engineering",
+					InputTokens:      700_000,
+					OutputTokens:     500_000,
+					EstimatedCostUSD: 0.5364,
+				},
+				{
+					Model:            "qwen3-8b",
+					Namespace:        "engineering",
+					InputTokens:      500_000,
+					OutputTokens:     300_000,
+					EstimatedCostUSD: 0.3577,
+				},
+			},
+			CloudComparison: []finopsv1alpha1.CloudComparisonEntry{
+				{
+					Provider:              "Anthropic",
+					Model:                 "claude-sonnet-4-6",
+					EstimatedCloudCostUSD: 15.60,
+					SavingsUSD:            14.70,
+					SavingsPercent:        94.2,
+				},
+				{
+					Provider:              "OpenAI",
+					Model:                 "gpt-5.4",
+					EstimatedCloudCostUSD: 15.00,
+					SavingsUSD:            14.10,
+					SavingsPercent:        94.0,
+				},
+			},
+		},
+	}
+}
+
+func parseCSV(t *testing.T, data []byte) ([]string, [][]string) {
+	t.Helper()
+	r := csv.NewReader(bytes.NewReader(data))
+	r.FieldsPerRecord = -1
+	records, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("parsing CSV: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("empty CSV")
+	}
+	return records[0], records[1:]
+}
+
+func columnIdx(header []string, name string) int {
+	for i, h := range header {
+		if h == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestWrite_HeaderContainsFOCUSStandardAndExtensions(t *testing.T) {
+	var buf bytes.Buffer
+	err := Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	header, _ := parseCSV(t, buf.Bytes())
+
+	// Standard FOCUS v1 columns every consumer expects.
+	for _, c := range []string{
+		"BilledCost", "EffectiveCost", "ChargePeriodStart", "ChargePeriodEnd",
+		"Currency", "ServiceName", "ServiceCategory", "ResourceId", "UsageQuantity",
+		"UsageUnit", "SubAccountId", "Tags",
+	} {
+		if columnIdx(header, c) < 0 {
+			t.Errorf("missing standard FOCUS column %q", c)
+		}
+	}
+
+	// InferCost extensions with the FOCUS-required x- prefix.
+	for _, c := range []string{
+		"x-InferGpuModel", "x-InferTokensInput", "x-InferTokensOutput",
+		"x-InferPUEFactor", "x-InferCloudEquivalentProvider", "x-InferSavingsPercent",
+	} {
+		if columnIdx(header, c) < 0 {
+			t.Errorf("missing InferCost extension column %q", c)
+		}
+	}
+}
+
+func TestWrite_OneRowPerModel(t *testing.T) {
+	var buf bytes.Buffer
+	err := Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	_, rows := parseCSV(t, buf.Bytes())
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 model rows, got %d", len(rows))
+	}
+}
+
+func TestWrite_RolluprowWhenNoModelBreakdown(t *testing.T) {
+	r := sampleReport()
+	r.Status.ByModel = nil
+
+	var buf bytes.Buffer
+	err := Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{r},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_, rows := parseCSV(t, buf.Bytes())
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 rollup row when ByModel is empty, got %d", len(rows))
+	}
+}
+
+func TestWrite_BilledCostMatchesModelBreakdown(t *testing.T) {
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+
+	header, rows := parseCSV(t, buf.Bytes())
+	billedIdx := columnIdx(header, "BilledCost")
+	skuIdx := columnIdx(header, "SkuId")
+
+	for _, row := range rows {
+		switch row[skuIdx] {
+		case "qwen3-coder-30b":
+			if row[billedIdx] != "0.5364" {
+				t.Errorf("qwen3-coder-30b BilledCost = %s, want 0.5364", row[billedIdx])
+			}
+		case "qwen3-8b":
+			if row[billedIdx] != "0.3577" {
+				t.Errorf("qwen3-8b BilledCost = %s, want 0.3577", row[billedIdx])
+			}
+		}
+	}
+}
+
+func TestWrite_CloudEquivalentPicksHighestSavings(t *testing.T) {
+	// Sample has Anthropic ($14.70 savings) and OpenAI ($14.10). Anthropic wins.
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	header, rows := parseCSV(t, buf.Bytes())
+	provIdx := columnIdx(header, "x-InferCloudEquivalentProvider")
+	for _, row := range rows {
+		if row[provIdx] != "Anthropic" {
+			t.Errorf("x-InferCloudEquivalentProvider = %q, want Anthropic (highest savings)", row[provIdx])
+		}
+	}
+}
+
+func TestWrite_PeriodEmittedAsRFC3339(t *testing.T) {
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	header, rows := parseCSV(t, buf.Bytes())
+	startIdx := columnIdx(header, "ChargePeriodStart")
+	endIdx := columnIdx(header, "ChargePeriodEnd")
+	for _, row := range rows {
+		if _, err := time.Parse(time.RFC3339, row[startIdx]); err != nil {
+			t.Errorf("ChargePeriodStart %q not RFC3339: %v", row[startIdx], err)
+		}
+		if _, err := time.Parse(time.RFC3339, row[endIdx]); err != nil {
+			t.Errorf("ChargePeriodEnd %q not RFC3339: %v", row[endIdx], err)
+		}
+	}
+}
+
+func TestWrite_CurrencyAlwaysUSD(t *testing.T) {
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	header, rows := parseCSV(t, buf.Bytes())
+	curIdx := columnIdx(header, "Currency")
+	for _, row := range rows {
+		if row[curIdx] != "USD" {
+			t.Errorf("Currency = %q, want USD", row[curIdx])
+		}
+	}
+}
+
+func TestWrite_ServiceCategoryMatchesFOCUSEnum(t *testing.T) {
+	// FOCUS v1 defines "AI and Machine Learning" as a canonical
+	// ServiceCategory value. Drifting from the enum breaks downstream
+	// importers that validate categories.
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{sampleReport()},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	header, rows := parseCSV(t, buf.Bytes())
+	idx := columnIdx(header, "ServiceCategory")
+	for _, row := range rows {
+		if row[idx] != "AI and Machine Learning" {
+			t.Errorf("ServiceCategory = %q, want 'AI and Machine Learning'", row[idx])
+		}
+	}
+}
+
+func TestWrite_MultipleReportsSortedDeterministically(t *testing.T) {
+	r1 := sampleReport()
+	r1.Name = "engineering-daily"
+	r1.Namespace = "engineering"
+	r2 := sampleReport()
+	r2.Name = "research-daily"
+	r2.Namespace = "research"
+
+	// Shuffle input order.
+	var buf bytes.Buffer
+	_ = Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{r2, r1},
+		Profiles: map[string]finopsv1alpha1.CostProfile{"shadowstack-5060ti": sampleProfile()},
+	})
+	header, rows := parseCSV(t, buf.Bytes())
+	subIdx := columnIdx(header, "SubAccountId")
+	// Engineering must come before Research even though we fed them in r2,r1.
+	if rows[0][subIdx] != "engineering" {
+		t.Errorf("first row SubAccountId = %q, want engineering", rows[0][subIdx])
+	}
+}
+
+func TestWrite_MissingProfileDoesNotCrash(t *testing.T) {
+	r := sampleReport()
+	r.Spec.CostProfileRef = "does-not-exist"
+
+	var buf bytes.Buffer
+	if err := Write(&buf, ExportInput{
+		Reports:  []finopsv1alpha1.UsageReport{r},
+		Profiles: map[string]finopsv1alpha1.CostProfile{},
+	}); err != nil {
+		t.Fatalf("Write failed on missing profile: %v", err)
+	}
+
+	header, rows := parseCSV(t, buf.Bytes())
+	gpuIdx := columnIdx(header, "x-InferGpuModel")
+	for _, row := range rows {
+		if row[gpuIdx] != "" {
+			t.Errorf("expected empty x-InferGpuModel for missing profile, got %q", row[gpuIdx])
+		}
+	}
+}
+
+func TestWrite_EmptyInputEmitsOnlyHeader(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, ExportInput{}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	output := buf.String()
+	if !strings.HasPrefix(output, "BilledCost,") {
+		t.Errorf("output should start with header, got: %s", output[:min(60, len(output))])
+	}
+	if strings.Count(output, "\n") != 1 {
+		t.Errorf("expected only the header line, got %d lines", strings.Count(output, "\n"))
+	}
+}

--- a/pkg/cli/export.go
+++ b/pkg/cli/export.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
+	"github.com/defilantech/infercost/internal/focus"
+)
+
+type exportFocusOptions struct {
+	namespace string
+	output    string
+	period    string
+	region    string
+}
+
+// NewExportCommand returns the top-level `infercost export` command. Today it
+// has one subcommand (focus) but export is its own namespace so future
+// formats (e.g. per-provider-native schemas) don't crowd the root command
+// surface.
+func NewExportCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export InferCost data in interchange formats",
+		Long:  `Export InferCost cost data in formats that drop into external FinOps tooling.`,
+	}
+	cmd.AddCommand(newExportFocusCommand())
+	return cmd
+}
+
+func newExportFocusCommand() *cobra.Command {
+	opts := &exportFocusOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "focus",
+		Short: "Export usage reports as FOCUS-compatible CSV",
+		Long: `Export UsageReport data as a FOCUS (FinOps Open Cost and Usage Specification)
+compatible CSV. Standard FOCUS v1 columns are populated for billing/usage
+integration; on-prem inference specifics (GPU model, token counts, power,
+cloud-equivalent cost) live in x-Infer* extension columns.
+
+Importable into Kubecost, Cloudability, or any FOCUS-aware BI pipeline.
+See docs/focus-export.md for the full schema.`,
+		Example: `  # Write a CSV for all UsageReports in the cluster
+  infercost export focus --out report.csv
+
+  # Scope to one namespace and tag with region for multi-cluster rollups
+  infercost export focus --namespace engineering --region us-east-1 --out eng.csv
+
+  # Stream to stdout for piping into analysis
+  infercost export focus | awk -F, '$1>0'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExportFocus(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "",
+		"Kubernetes namespace (default: all)")
+	cmd.Flags().StringVarP(&opts.output, "out", "o", "",
+		"Output file path (default: stdout)")
+	cmd.Flags().StringVar(&opts.period, "period", "",
+		"Filter to reports whose status.period matches this value (e.g. 2026-04)")
+	cmd.Flags().StringVar(&opts.region, "region", "",
+		"Value for the FOCUS Region column (e.g. data center or cluster name)")
+
+	return cmd
+}
+
+func runExportFocus(ctx context.Context, opts *exportFocusOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	clients, err := newK8sClient()
+	if err != nil {
+		return err
+	}
+
+	reports, profiles, err := fetchReportsAndProfiles(ctx, clients.client, opts.namespace, opts.period)
+	if err != nil {
+		return err
+	}
+	if len(reports) == 0 {
+		return fmt.Errorf(
+			"no UsageReports matched (namespace=%q, period=%q) — nothing to export",
+			opts.namespace, opts.period,
+		)
+	}
+
+	out := os.Stdout
+	if opts.output != "" {
+		f, err := os.Create(opts.output)
+		if err != nil {
+			return fmt.Errorf("creating output file: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		out = f
+	}
+
+	if err := focus.Write(out, focus.ExportInput{
+		Reports:  reports,
+		Profiles: profiles,
+		Region:   opts.region,
+	}); err != nil {
+		return fmt.Errorf("writing FOCUS CSV: %w", err)
+	}
+
+	if opts.output != "" {
+		fmt.Fprintf(os.Stderr, "Wrote %d UsageReports to %s\n", len(reports), opts.output)
+	}
+	return nil
+}
+
+// fetchReportsAndProfiles loads the UsageReports (optionally scoped by
+// namespace and period) and every CostProfile they reference. The profile
+// lookup is a map for O(1) access during row emission; missing profiles are
+// tolerated so the export doesn't fail on stale references.
+func fetchReportsAndProfiles(
+	ctx context.Context,
+	c client.Client,
+	namespace, period string,
+) ([]finopsv1alpha1.UsageReport, map[string]finopsv1alpha1.CostProfile, error) {
+	var reportList finopsv1alpha1.UsageReportList
+	listOpts := []client.ListOption{}
+	if namespace != "" {
+		listOpts = append(listOpts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, &reportList, listOpts...); err != nil {
+		return nil, nil, fmt.Errorf("listing UsageReports: %w", err)
+	}
+
+	reports := reportList.Items
+	if period != "" {
+		filtered := reports[:0]
+		for _, r := range reports {
+			if r.Status.Period == period {
+				filtered = append(filtered, r)
+			}
+		}
+		reports = filtered
+	}
+
+	profiles := make(map[string]finopsv1alpha1.CostProfile)
+	for _, r := range reports {
+		if _, seen := profiles[r.Spec.CostProfileRef]; seen {
+			continue
+		}
+		var p finopsv1alpha1.CostProfile
+		err := c.Get(ctx, client.ObjectKey{Name: r.Spec.CostProfileRef, Namespace: r.Namespace}, &p)
+		if err == nil {
+			profiles[r.Spec.CostProfileRef] = p
+		}
+		// Missing profile is tolerated — focus.Write produces rows with empty
+		// x-Infer* fields rather than failing the whole export.
+	}
+	return reports, profiles, nil
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -23,6 +23,7 @@ with LLMKube, llama.cpp, and vLLM.`,
 	cmd.AddCommand(NewCompareCommand())
 	cmd.AddCommand(NewBudgetCommand())
 	cmd.AddCommand(NewUsersCommand())
+	cmd.AddCommand(NewExportCommand())
 	cmd.AddCommand(NewVersionCommand())
 
 	return cmd


### PR DESCRIPTION
## Why

The positioning angle against OpenCost is \"FOCUS-compatible on-prem inference economics.\" That claim is only real when we actually emit FOCUS.

## What's shipped

### \`internal/focus\` package

Emits CSV matching [FOCUS v1](https://focus.finops.org/). Zero k8s-client dependency — \`ExportInput\` carries pre-fetched reports + profiles so the logic is a pure function that unit-tests cleanly.

**Standard FOCUS columns populated** with the closest natural analogue:
- \`ServiceName\` = \`On-Prem AI Inference\`
- \`ServiceCategory\` = \`AI and Machine Learning\` (FOCUS v1 canonical enum)
- \`UsageUnit\` = \`Tokens\`, \`PricingUnit\` = \`1M Tokens\`
- \`ChargeCategory\` = \`Usage\`
- \`BilledCost\` = \`EffectiveCost\` = \`ListCost\` = \`ContractedCost\` (no discount model on-prem)
- \`SubAccountId\` = Kubernetes namespace (for per-team chargeback)
- \`Tags\` = JSON object with report/schedule/model/gpuModel

**\`x-Infer*\` extensions** for dimensions FOCUS v1 does not model:
- \`x-InferGpuModel\`, \`x-InferGpuCount\`
- \`x-InferTokensInput\`, \`x-InferTokensOutput\`
- \`x-InferAmortizationYears\`, \`x-InferElectricityRatePerKWh\`, \`x-InferPUEFactor\`
- \`x-InferCloudEquivalentProvider\`, \`x-InferCloudEquivalentModel\`, \`x-InferCloudEquivalentCostUSD\`
- \`x-InferSavingsUSD\`, \`x-InferSavingsPercent\`

**Row shape**: One row per \`(UsageReport, ModelCostBreakdown)\`. Reports with no model breakdown emit a rollup row so a misconfigured namespace doesn't disappear from finance exports.

### CLI

New \`infercost export focus\` subcommand:

\`\`\`
infercost export focus [--namespace NS] [--period YYYY-MM] [--region R] [--out FILE]
\`\`\`

Writes to a file or streams to stdout; pipes naturally into awk / jq for ad-hoc analysis.

### Docs

\`docs/focus-export.md\` carries the full column reference, FOCUS alignment notes (how we plan to migrate to standard names when FOCUS v1.1 covers AI inference), and import guidance for Kubecost / Cloudability.

## Tests (11 in \`internal/focus\`)

Header contract, row count by shape, per-model cost attribution, cloud-equivalent \"highest savings\" selection, RFC3339 period format, Currency=USD invariant, FOCUS ServiceCategory enum alignment, deterministic sort with shuffled input, missing-profile tolerance, and empty-input header-only output.

\`\`\`
$ go test ./... -count=1
ok  github.com/defilantech/infercost/internal/focus       1.39s
$ make lint
0 issues.
\`\`\`

## Why this matters

Having a FOCUS exporter unblocks:

1. **The OpenCost #3533 comment** — the runbook in \`docs/launch/opencost-engagement.md\` requires we ship a FOCUS-compatible exporter before posting. This PR satisfies that gate.
2. **CNCF Landscape FinOps subcategory credibility** — \"FinOps Foundation spec compatible\" is a more defensible claim than \"cost tracking.\"
3. **Enterprise evaluators** who already have a FOCUS pipeline (Kubecost, Cloudability) can import InferCost data the same day they discover the tool.

## Follow-up

- Migrate \`x-Infer*\` to standard column names when FOCUS v1.1 ships with AI coverage (minor release with documented alias)
- Add an optional REST endpoint \`/api/v1/export/focus\` that streams the same CSV without needing CLI access