### PR TITLE
docs: batch-fill missing godoc comments

### DIFF
--- a/api/v1alpha1/usagereport_types.go
+++ b/api/v1alpha1/usagereport_types.go
@@ -25,8 +25,11 @@ import (
 type ReportSchedule string
 
 const (
-	ReportScheduleDaily   ReportSchedule = "daily"
-	ReportScheduleWeekly  ReportSchedule = "weekly"
+	// ReportScheduleDaily generates a report once per calendar day.
+	ReportScheduleDaily ReportSchedule = "daily"
+	// ReportScheduleWeekly generates a report once per calendar week.
+	ReportScheduleWeekly ReportSchedule = "weekly"
+	// ReportScheduleMonthly generates a report once per calendar month.
 	ReportScheduleMonthly ReportSchedule = "monthly"
 )
 

--- a/internal/controller/costprofile_controller.go
+++ b/internal/controller/costprofile_controller.go
@@ -78,6 +78,10 @@ type CostProfileReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
+// Reconcile computes the hourly infrastructure cost for a CostProfile by combining
+// hardware economics (amortization, electricity) with real-time GPU power draw from
+// DCGM or TDP fallback. It scrapes inference pod token metrics, updates Prometheus
+// metrics and the API store, and writes computed costs to the CostProfile status.
 func (r *CostProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 

--- a/pkg/cli/budget.go
+++ b/pkg/cli/budget.go
@@ -23,6 +23,8 @@ type budgetOptions struct {
 	allNamespaces bool
 }
 
+// NewBudgetCommand creates the "budget" CLI subcommand that lists TokenBudget
+// resources and their monthly spend utilization.
 func NewBudgetCommand() *cobra.Command {
 	opts := &budgetOptions{}
 

--- a/pkg/cli/compare.go
+++ b/pkg/cli/compare.go
@@ -22,6 +22,8 @@ type compareOptions struct {
 	monthly   bool
 }
 
+// NewCompareCommand creates the "compare" CLI subcommand that compares on-premises
+// inference costs against major cloud API providers (OpenAI, Anthropic, Google).
 func NewCompareCommand() *cobra.Command {
 	opts := &compareOptions{}
 

--- a/pkg/cli/status.go
+++ b/pkg/cli/status.go
@@ -27,6 +27,9 @@ type statusOptions struct {
 	allNamespaces bool
 }
 
+// NewStatusCommand creates the "status" CLI subcommand that displays real-time
+// cost data for all CostProfiles and inference workloads, including hardware costs,
+// GPU power draw, active models, and token throughput.
 func NewStatusCommand() *cobra.Command {
 	opts := &statusOptions{}
 

--- a/pkg/cli/users.go
+++ b/pkg/cli/users.go
@@ -11,6 +11,8 @@ type usersOptions struct {
 	top       int
 }
 
+// NewUsersCommand creates the "users" CLI subcommand for per-user inference cost
+// attribution. Requires LiteLLM integration to be configured on the InferCost operator.
 func NewUsersCommand() *cobra.Command {
 	opts := &usersOptions{}
 

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -8,11 +8,16 @@ import (
 
 var (
 	// Set via ldflags at build time.
-	Version   = "dev"
+	// Version is the release version string (defaults to "dev").
+	Version = "dev"
+	// GitCommit is the git commit hash the binary was built from (defaults to "unknown").
 	GitCommit = "unknown"
+	// BuildDate is the date/time the binary was built (defaults to "unknown").
 	BuildDate = "unknown"
 )
 
+// NewVersionCommand creates the "version" CLI subcommand that prints the
+// InferCost version, git commit, and build date.
 func NewVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
## What

Fills in missing godoc comments on 12 exported Go symbols across 3 packages — 7 files touched. Additive-only diff.

## Why

Discoverability. Exported functions, methods, types, constants, and variables in `api/v1alpha1`, `internal/controller`, and `pkg/cli` were missing godoc comments, which meant `go doc`, IDE hovers, and `pkg.go.dev` rendered blanks for them. This closes the gap for the current exported surface.

## Replaces #20

This PR supersedes #20. The original was auto-updated against main with a merge commit that lacked DCO sign-off; rather than force-push fix a broken merge history, this PR cherry-picks the three original signed-off commits onto a fresh branch so the history is linear and every commit passes DCO.

| Package | Files touched | Symbols documented |
|---|---|---|
| `api/v1alpha1` | 1 | 3 (ReportSchedule* constants) |
| `internal/controller` | 1 | 1 (CostProfileReconciler.Reconcile) |
| `pkg/cli` | 5 | 8 (NewBudgetCommand, NewCompareCommand, NewStatusCommand, NewUsersCommand, NewVersionCommand, Version, GitCommit, BuildDate) |

## Verification

```
$ go test ./... -count=1
ok  all packages
$ make lint
0 issues.
```

## Closes

- Closes #20 (superseded, same changes on a clean linear history)