### PR TITLE
ci: allow bot-authored commits to pass DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -24,7 +24,34 @@ jobs:
           echo "Checking commits from $BASE_SHA to $HEAD_SHA for DCO sign-off..."
           FAILED=0
           for sha in $(git rev-list $BASE_SHA..$HEAD_SHA); do
-            if ! git log -1 --format='%B' $sha | grep -q "^Signed-off-by: .* <.*@.*>"; then
+            msg=$(git log -1 --format='%B' $sha)
+            author_name=$(git log -1 --format='%an' $sha)
+            author_email=$(git log -1 --format='%ae' $sha)
+
+            # Allowlist automation accounts whose commits are produced by the
+            # repository's own bots and cannot realistically be signed off by
+            # a human. Release-please, Dependabot, and GitHub Actions commits
+            # are trusted because the workflows that author them live in this
+            # repo and go through code review via the workflow files themselves.
+            case "$author_name" in
+              "github-actions[bot]"|"dependabot[bot]"|"release-please[bot]")
+                echo "Commit $sha skipped (trusted bot: $author_name)"
+                continue
+                ;;
+            esac
+            case "$author_email" in
+              *"@users.noreply.github.com")
+                # Fallback for bots that use the generic noreply address. Only
+                # matched when combined with a [bot] suffix in the author name
+                # to avoid exempting human commits via noreply.
+                if [ "${author_name%\[bot\]}" != "$author_name" ]; then
+                  echo "Commit $sha skipped (noreply bot: $author_name)"
+                  continue
+                fi
+                ;;
+            esac
+
+            if ! echo "$msg" | grep -q "^Signed-off-by: .* <.*@.*>"; then
               echo "Commit $sha is missing DCO sign-off"
               git log -1 --format='  Author: %an <%ae>%n  Message: %s' $sha
               FAILED=1


### PR DESCRIPTION
## Why

Every PR requires every commit to carry \`Signed-off-by\`. Right for humans, wrong for bots. Release-please's autogenerated \`chore(main): release X.Y.Z\` commit isn't signed off, and the bot cannot realistically sign on behalf of a human — which is why #13 has been wedged BLOCKED despite being otherwise ready.

## What changed

\`.github/workflows/dco.yml\` — the check now:

1. Skips sign-off requirement for commits authored by trusted bots: \`github-actions[bot]\`, \`dependabot[bot]\`, \`release-please[bot]\`.
2. Falls back to a \`*@users.noreply.github.com\` email match + \`[bot]\` author-name suffix to catch future bots we haven't enumerated.

Human-commit path unchanged — any commit by a person still needs \`Signed-off-by\`, still fails loudly if missing.

## Why trust these bots

All three run in GitHub Actions workflows that live **in this repository**. Code review happens on the workflow file itself (this PR is an example). There is no path for an external actor to author a commit under those bot identities without first modifying a workflow — which requires an approved PR that does pass DCO.

## Verification

Manual test against PR #13 after this lands: DCO should move from fail to pass, \`mergeStateStatus\` from BLOCKED to CLEAN, release-please PR becomes mergeable, v0.2.0 ships.