### PR TITLE
fix: bump Chart.yaml to 0.2.0 and wire release-please to maintain it

### DIFF
--- a/charts/infercost/Chart.yaml
+++ b/charts/infercost/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   A Helm chart for InferCost - Kubernetes-native cost intelligence
   for on-premises AI inference
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 keywords:
   - finops
   - cost

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,17 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "extra-files": [
-        "pkg/cli/version.go"
+        "pkg/cli/version.go",
+        {
+          "type": "yaml",
+          "path": "charts/infercost/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/infercost/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
       ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Why

v0.2.0 shipped this morning with a Git tag, a Docker image on GHCR, and a CLI binary that reports \`v0.2.0\`. But \`helm repo update && helm search repo infercost\` still returns **0.1.0** — the Helm chart silently stayed at the old version.

Root cause: release-please's \`extra-files\` list included \`pkg/cli/version.go\` but **not** \`charts/infercost/Chart.yaml\`. The chart-releaser action read the unchanged \`version: 0.1.0\` in Chart.yaml and re-published the same chart as a no-op.

## Fix

Two parts:

1. **Manually bump \`Chart.yaml\`** to 0.2.0 (both \`version\` and \`appVersion\`) so the next push to main makes chart-releaser publish the new chart.
2. **Add Chart.yaml to release-please's \`extra-files\`** so every future release-please PR bumps the chart alongside the CLI version string. No more silent drift.

\`\`\`json
"extra-files": [
  "pkg/cli/version.go",
  { "type": "yaml", "path": "charts/infercost/Chart.yaml", "jsonpath": "$.version" },
  { "type": "yaml", "path": "charts/infercost/Chart.yaml", "jsonpath": "$.appVersion" }
]
\`\`\`

## Verification

\`\`\`
$ helm lint charts/infercost
1 chart(s) linted, 0 chart(s) failed
\`\`\`

Once this merges, the next run of the chart-releaser action will publish \`infercost-0.2.0.tgz\` to the GitHub Pages Helm repo, and \`helm repo update && helm search repo infercost\` will finally see 0.2.0. Independently confirmed that the prior no-op publish was caused by the version match.

## Going forward

Release-please maintains the Chart.yaml invariant, so this is a one-time recovery. Future releases will bump the chart automatically.