### PR TITLE
feat: marginalCostPerMillionTokens from DCGM-sampled energy (#38)

### DIFF
--- a/api/v1alpha1/usagereport_types.go
+++ b/api/v1alpha1/usagereport_types.go
@@ -127,8 +127,27 @@ type UsageReportStatus struct {
 	EstimatedCostUSD float64 `json:"estimatedCostUSD,omitempty"`
 
 	// costPerMillionTokens is the effective blended cost per million tokens.
+	// Includes hardware amortization across the full reporting period —
+	// sensitive to utilization. Use in tandem with marginalCostPerMillionTokens
+	// when comparing against cloud API pricing.
 	// +optional
 	CostPerMillionTokens float64 `json:"costPerMillionTokens,omitempty"`
+
+	// marginalCostPerMillionTokens is the electricity-only $/MTok computed
+	// across active (above-threshold) samples in the reporting period. It
+	// excludes hardware amortization, so it answers "what did the marginal
+	// token actually cost in electricity?" — the right comparison for
+	// cloud APIs that also bill marginally. At saturated utilization this
+	// converges with costPerMillionTokens; at low utilization it diverges
+	// (amortized goes up, marginal stays flat).
+	// +optional
+	MarginalCostPerMillionTokens float64 `json:"marginalCostPerMillionTokens,omitempty"`
+
+	// activeEnergyKWh is the integrated energy drawn during active-threshold
+	// time across the reporting period, derived from DCGM power samples.
+	// Surfaced directly so operators can sanity-check the marginal cost math.
+	// +optional
+	ActiveEnergyKWh float64 `json:"activeEnergyKWh,omitempty"`
 
 	// gpuEfficiencyRatio is the fraction of GPU time spent on active inference (0.0-1.0).
 	// Derived from the same samples as utilizationPercent — the two fields move
@@ -184,6 +203,7 @@ type UsageReportStatus struct {
 // +kubebuilder:printcolumn:name="Period",type=string,JSONPath=`.status.period`
 // +kubebuilder:printcolumn:name="Cost ($)",type=number,JSONPath=`.status.estimatedCostUSD`,format=float
 // +kubebuilder:printcolumn:name="$/MTok",type=number,JSONPath=`.status.costPerMillionTokens`,format=float
+// +kubebuilder:printcolumn:name="$/MTok (marginal)",type=number,JSONPath=`.status.marginalCostPerMillionTokens`,format=float,priority=1
 // +kubebuilder:printcolumn:name="Input Tokens",type=integer,JSONPath=`.status.inputTokens`
 // +kubebuilder:printcolumn:name="Output Tokens",type=integer,JSONPath=`.status.outputTokens`
 // +kubebuilder:printcolumn:name="Util %",type=number,JSONPath=`.status.utilizationPercent`,format=float,priority=1

--- a/config/crd/bases/finops.infercost.ai_usagereports.yaml
+++ b/config/crd/bases/finops.infercost.ai_usagereports.yaml
@@ -26,6 +26,11 @@ spec:
       jsonPath: .status.costPerMillionTokens
       name: $/MTok
       type: number
+    - format: float
+      jsonPath: .status.marginalCostPerMillionTokens
+      name: $/MTok (marginal)
+      priority: 1
+      type: number
     - jsonPath: .status.inputTokens
       name: Input Tokens
       type: integer
@@ -98,6 +103,12 @@ spec:
             description: UsageReportStatus contains the computed cost report data.
               Populated by the controller.
             properties:
+              activeEnergyKWh:
+                description: |-
+                  activeEnergyKWh is the integrated energy drawn during active-threshold
+                  time across the reporting period, derived from DCGM power samples.
+                  Surfaced directly so operators can sanity-check the marginal cost math.
+                type: number
               activeHoursInPeriod:
                 description: |-
                   activeHoursInPeriod is how many hours of the reporting period had GPU
@@ -262,8 +273,11 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               costPerMillionTokens:
-                description: costPerMillionTokens is the effective blended cost per
-                  million tokens.
+                description: |-
+                  costPerMillionTokens is the effective blended cost per million tokens.
+                  Includes hardware amortization across the full reporting period —
+                  sensitive to utilization. Use in tandem with marginalCostPerMillionTokens
+                  when comparing against cloud API pricing.
                 type: number
               estimatedCostUSD:
                 description: estimatedCostUSD is the total computed on-prem cost for
@@ -285,6 +299,16 @@ spec:
                 description: lastUpdated is the timestamp of the last report computation.
                 format: date-time
                 type: string
+              marginalCostPerMillionTokens:
+                description: |-
+                  marginalCostPerMillionTokens is the electricity-only $/MTok computed
+                  across active (above-threshold) samples in the reporting period. It
+                  excludes hardware amortization, so it answers "what did the marginal
+                  token actually cost in electricity?" — the right comparison for
+                  cloud APIs that also bill marginally. At saturated utilization this
+                  converges with costPerMillionTokens; at low utilization it diverges
+                  (amortized goes up, marginal stays flat).
+                type: number
               outputTokens:
                 description: outputTokens is the total output/completion tokens across
                   all models.

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -13,11 +13,14 @@ one means, which question it answers, and when it misleads.
 | `activeHoursInPeriod` | Hours with power above the idle threshold | Numerator of utilization |
 | `totalHoursInPeriod` | Wall-clock hours elapsed in the period | Denominator of utilization |
 | `gpuEfficiencyRatio` | Same as `utilizationPercent / 100` | Compatibility with the Grafana dashboard |
+| `marginalCostPerMillionTokens` | Electricity-only \$ / 1M tokens during active time | What each token costs in power, once you own the hardware |
+| `activeEnergyKWh` | Integrated kWh across active intervals | Numerator of the marginal calculation, exposed so operators can sanity-check |
 
-Future fields (tracked in GitHub issues [#37–#41](https://github.com/defilantech/infercost/issues?q=is%3Aissue+label%3Aarea%2Fcost-model)):
+Future fields (tracked in GitHub issues [#37, #39, #41](https://github.com/defilantech/infercost/issues?q=is%3Aissue+label%3Aarea%2Fcost-model)):
 
-- `marginalCostPerMillionTokens` — electricity-only \$/MTok during active hours
-- Break-even tokens-per-day per cloud provider
+- Break-even tokens-per-day per cloud provider (#39)
+- Active-hour amortization (#37) — will replace the current wall-clock amortization denominator when enabled
+- Utilization-aware status message (#41)
 
 ## What's "active"?
 
@@ -67,14 +70,31 @@ comparison is one of:
 
 1. **Break-even tokens/day** (issue [#39](https://github.com/defilantech/infercost/issues/39)) — at
    what daily token volume does the on-prem bill match the cloud bill?
-2. **Marginal comparison** (issue [#38](https://github.com/defilantech/infercost/issues/38)) — compare
-   on-prem electricity-during-serving to cloud per-token.
+2. **Marginal comparison** (`marginalCostPerMillionTokens`) — compare
+   on-prem electricity-during-serving to cloud per-token. InferCost
+   computes this today from DCGM samples; see the example below.
 
-Until those land, the most honest framing is:
+### Marginal vs amortized — an example
 
-> *Today: \$0.066 on 3,993 tokens, utilization 4%. At 100% utilization
-> on this hardware, the same \$0.066 would have bought ~100× more
-> tokens.*
+Take the live shadowstack cluster on a low-traffic day at 4% utilization:
+
+| Metric | Value | What it means |
+|---|---|---|
+| `costPerMillionTokens` | ~\$16 | Full cost of ownership at today's throughput |
+| `marginalCostPerMillionTokens` | ~\$0.004 | Electricity you actually burned generating tokens |
+| Anthropic Opus output rate | ~\$15 / MTok | Marginal cloud pricing (all you ever pay) |
+| OpenAI GPT-5.4-nano output rate | ~\$0.40 / MTok | Marginal cloud pricing |
+
+Comparing amortized on-prem (~\$16) to Opus (~\$15) says "cloud wins."
+Comparing marginal on-prem (~\$0.004) to Opus (~\$15) says "on-prem
+wins by 3750×." Neither number is wrong; they answer different
+questions.
+
+The honest answer is: *at 4% utilization you're wasting most of the
+hardware you already bought. Route more traffic to it (or buy a
+smaller GPU) before comparing to cloud APIs.* At 100% utilization the
+amortized and marginal numbers converge — on-prem wins decisively at
+any non-trivial scale.
 
 ## When to raise `idleWattsThreshold`
 

--- a/internal/controller/usagereport_controller.go
+++ b/internal/controller/usagereport_controller.go
@@ -110,12 +110,18 @@ func (r *UsageReportReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		costPerMillion = totalCost / (float64(totalTokens) / 1_000_000)
 	}
 
-	// Utilization: how much of the period did the GPUs actually work?
-	// Zero when no sampler is wired or no samples overlap the window.
+	// Utilization + energy: how much of the period did the GPUs actually
+	// work, and how much electricity did they burn while doing it? All zero
+	// when no sampler is wired or no samples overlap the window.
 	var activeHours, totalHoursObserved, utilizationPercent, gpuEfficiency float64
+	var activeEnergyKWh, marginalCostPerMillion float64
 	if r.Sampler != nil {
 		key := sampleKeyFor(&profile)
-		activeHours, totalHoursObserved = r.Sampler.ActiveAndTotalHours(key, periodStart, periodEnd)
+		w := r.Sampler.Summarize(key, periodStart, periodEnd)
+		activeHours = w.ActiveHours
+		totalHoursObserved = w.TotalHours
+		activeEnergyKWh = w.ActiveEnergyKWh
+
 		// Use the wall-clock period denominator for user-facing utilization
 		// — observedHours can lag (sampler just started, controller restart)
 		// and dividing by it would overstate utilization.
@@ -123,23 +129,38 @@ func (r *UsageReportReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			utilizationPercent = (activeHours / hoursInPeriod) * 100.0
 			gpuEfficiency = activeHours / hoursInPeriod
 		}
+
+		// Marginal $/MTok: the electricity actually drawn during active
+		// serving, divided by tokens served. Excludes amortization (sunk
+		// cost) and idle electricity (you'd pay that regardless). PUE
+		// applied because cooling and other overhead scale with draw.
+		if totalTokens > 0 && activeEnergyKWh > 0 {
+			pue := profile.Spec.Electricity.PUEFactor
+			if pue <= 0 {
+				pue = 1.0
+			}
+			marginalCostUSD := activeEnergyKWh * profile.Spec.Electricity.RatePerKWh * pue
+			marginalCostPerMillion = marginalCostUSD / (float64(totalTokens) / 1_000_000.0)
+		}
 	}
 
 	periodStr := formatPeriod(report.Spec.Schedule, periodStart)
 	computed := computedStatus{
-		period:               periodStr,
-		periodStart:          periodStart,
-		periodEnd:            periodEnd,
-		inputTokens:          totalIn,
-		outputTokens:         totalOut,
-		totalCost:            totalCost,
-		costPerMillionTokens: costPerMillion,
-		byModel:              byModel,
-		byNamespace:          byNamespace,
-		utilizationPercent:   utilizationPercent,
-		gpuEfficiencyRatio:   gpuEfficiency,
-		activeHoursInPeriod:  activeHours,
-		totalHoursInPeriod:   hoursInPeriod,
+		period:                       periodStr,
+		periodStart:                  periodStart,
+		periodEnd:                    periodEnd,
+		inputTokens:                  totalIn,
+		outputTokens:                 totalOut,
+		totalCost:                    totalCost,
+		costPerMillionTokens:         costPerMillion,
+		marginalCostPerMillionTokens: marginalCostPerMillion,
+		activeEnergyKWh:              activeEnergyKWh,
+		byModel:                      byModel,
+		byNamespace:                  byNamespace,
+		utilizationPercent:           utilizationPercent,
+		gpuEfficiencyRatio:           gpuEfficiency,
+		activeHoursInPeriod:          activeHours,
+		totalHoursInPeriod:           hoursInPeriod,
 	}
 	// Silence unused-var warning when sampler is wired but period has no observations yet.
 	_ = totalHoursObserved
@@ -338,15 +359,17 @@ func buildBreakdowns(
 // passed from the computation phase to the write phase so the Reconcile entry
 // point stays short enough to read top-to-bottom.
 type computedStatus struct {
-	period               string
-	periodStart          time.Time
-	periodEnd            time.Time
-	inputTokens          int64
-	outputTokens         int64
-	totalCost            float64
-	costPerMillionTokens float64
-	byModel              []finopsv1alpha1.ModelCostBreakdown
-	byNamespace          []finopsv1alpha1.NamespaceCostBreakdown
+	period                       string
+	periodStart                  time.Time
+	periodEnd                    time.Time
+	inputTokens                  int64
+	outputTokens                 int64
+	totalCost                    float64
+	costPerMillionTokens         float64
+	marginalCostPerMillionTokens float64
+	activeEnergyKWh              float64
+	byModel                      []finopsv1alpha1.ModelCostBreakdown
+	byNamespace                  []finopsv1alpha1.NamespaceCostBreakdown
 	// utilization-derived fields (all zero when no sampler is wired)
 	utilizationPercent  float64
 	gpuEfficiencyRatio  float64
@@ -373,6 +396,8 @@ func (r *UsageReportReconciler) applyStatusIfChanged(ctx context.Context, report
 	report.Status.OutputTokens = c.outputTokens
 	report.Status.EstimatedCostUSD = c.totalCost
 	report.Status.CostPerMillionTokens = c.costPerMillionTokens
+	report.Status.MarginalCostPerMillionTokens = c.marginalCostPerMillionTokens
+	report.Status.ActiveEnergyKWh = c.activeEnergyKWh
 	report.Status.ByModel = c.byModel
 	report.Status.ByNamespace = c.byNamespace
 	report.Status.UtilizationPercent = c.utilizationPercent

--- a/internal/utilization/sampler.go
+++ b/internal/utilization/sampler.go
@@ -88,30 +88,50 @@ func (s *Sampler) Record(key string, powerW, activeThresholdW float64) {
 	s.gcLocked(key, now)
 }
 
-// ActiveAndTotalHours returns (activeHours, totalHours) observed for the key
-// between start (inclusive) and end (exclusive). Windows with no samples
-// return (0, 0) — callers should treat that as "unknown" rather than "idle"
-// to avoid falsely reporting 0% utilization during bootstrap.
+// WindowSummary describes the aggregated behavior of a CostProfile over a
+// [start, end) window. Populated by (*Sampler).Summarize. All fields are
+// zero when no samples overlap the window.
+type WindowSummary struct {
+	ActiveHours     float64 // wall-clock hours with power above idle threshold
+	TotalHours      float64 // wall-clock hours actually observed (never the whole window if samples didn't span it)
+	ActiveEnergyKWh float64 // integrated kilowatt-hours consumed during active intervals only
+	TotalEnergyKWh  float64 // integrated kilowatt-hours consumed across every observed sample
+}
+
+// ActiveAndTotalHours is a convenience wrapper around Summarize that returns
+// only the hours fields. Kept because UsageReport's utilization computation
+// doesn't need energy, and this signature is easier to read at the callsite.
+func (s *Sampler) ActiveAndTotalHours(key string, start, end time.Time) (float64, float64) {
+	w := s.Summarize(key, start, end)
+	return w.ActiveHours, w.TotalHours
+}
+
+// Summarize aggregates samples for the key over the [start, end) window
+// and returns a WindowSummary with both time and energy totals.
 //
 // Integration rule: each sample represents its own state forward in time
 // until the next sample (or `end`, whichever comes first). A sample is
 // classified as "active" if its recorded PowerW exceeds the ActiveW
-// threshold that was in effect when it was recorded. Persisting the
-// threshold on each sample means a mid-period threshold change doesn't
-// retroactively relabel old samples.
+// threshold that was in effect when it was recorded. Energy is computed
+// as rectangular integration: the sample's PowerW (W) is held flat across
+// the interval it represents, so energy_kWh for that interval equals
+// PowerW × duration_h / 1000. This is the same shape of math Prometheus
+// uses for rate() windows — good enough for billing-accuracy when the
+// sample spacing is small relative to the window (30s samples over a
+// 24h window gives 2880 rectangles).
 //
 // Gaps before the first sample (time between `start` and samples[0]) are
 // not credited — we treat them as "no data" rather than asserting an
 // idle state that was never observed.
-func (s *Sampler) ActiveAndTotalHours(key string, start, end time.Time) (float64, float64) {
+func (s *Sampler) Summarize(key string, start, end time.Time) WindowSummary {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	samples := s.samples[key]
 	if len(samples) == 0 {
-		return 0, 0
+		return WindowSummary{}
 	}
 
-	var activeSecs, totalSecs float64
+	var summary WindowSummary
 	for i, sample := range samples {
 		// Interval this sample represents: [sample.At, nextAt).
 		var nextAt time.Time
@@ -133,13 +153,18 @@ func (s *Sampler) ActiveAndTotalHours(key string, start, end time.Time) (float64
 			continue
 		}
 		secs := intervalEnd.Sub(intervalStart).Seconds()
-		totalSecs += secs
+		hours := secs / 3600.0
+		energyKWh := sample.PowerW * hours / 1000.0
+
+		summary.TotalHours += hours
+		summary.TotalEnergyKWh += energyKWh
 		if sample.PowerW > sample.ActiveW {
-			activeSecs += secs
+			summary.ActiveHours += hours
+			summary.ActiveEnergyKWh += energyKWh
 		}
 	}
 
-	return activeSecs / 3600.0, totalSecs / 3600.0
+	return summary
 }
 
 // Snapshot returns a copy of the samples for `key` ordered by time. Intended

--- a/internal/utilization/sampler_test.go
+++ b/internal/utilization/sampler_test.go
@@ -180,3 +180,38 @@ func TestDefaultIdleThresholdWatts(t *testing.T) {
 	got = DefaultIdleThresholdWatts(nil, 0)
 	approxEq(t, got, 30, "zero GPU count clamps to 1 for floor")
 }
+
+func TestSampler_SummarizeEnergy(t *testing.T) {
+	s := NewSampler()
+	clock := &fixedClock{cur: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)}
+	s.now = clock.now
+	start := clock.now()
+
+	// 300 W for 1 hour, then 10 W for 1 hour. Threshold 50 W.
+	// Active: first hour only. Active energy: 0.3 kWh. Total: 0.31 kWh.
+	s.Record("cluster/a", 300, 50)
+	clock.advance(time.Hour)
+	s.Record("cluster/a", 10, 50)
+	clock.advance(time.Hour)
+
+	w := s.Summarize("cluster/a", start, clock.now())
+	approxEq(t, w.TotalHours, 2.0, "total hours across the two intervals")
+	approxEq(t, w.ActiveHours, 1.0, "active hours (first sample above threshold only)")
+	approxEq(t, w.ActiveEnergyKWh, 0.3, "active energy: 300W × 1h = 300Wh = 0.3kWh")
+	approxEq(t, w.TotalEnergyKWh, 0.31, "total energy: 0.3 + (10W × 1h / 1000) = 0.31 kWh")
+}
+
+func TestSampler_SummarizeNoOverlapReturnsZero(t *testing.T) {
+	s := NewSampler()
+	clock := &fixedClock{cur: time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)}
+	s.now = clock.now
+	s.Record("cluster/a", 100, 50)
+
+	w := s.Summarize("cluster/a",
+		time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 22, 6, 0, 0, 0, time.UTC),
+	)
+	if w.TotalHours != 0 || w.ActiveEnergyKWh != 0 {
+		t.Fatalf("window before any samples should return zero summary, got %+v", w)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `marginalCostPerMillionTokens` and `activeEnergyKWh` to `UsageReport.status`, computed from the DCGM power samples already collected by the utilization sampler. Stacks on #42.

## Why

`costPerMillionTokens` includes wall-clock hardware amortization — it makes cloud APIs look cheap at low utilization even when the marginal electricity cost of generating a token on-prem is pennies. Marginal $/MTok is the fair comparison against cloud providers that also bill marginally.

## What changed

- `internal/utilization/sampler.go` — sampler grows `Summarize()` returning `WindowSummary{ActiveHours, TotalHours, ActiveEnergyKWh, TotalEnergyKWh}`. `ActiveAndTotalHours` becomes a shim. Rectangular integration: each sample's power × the interval it represents.
- `api/v1alpha1/usagereport_types.go` — new status fields `marginalCostPerMillionTokens` and `activeEnergyKWh`; priority-1 printcolumn for marginal.
- `internal/controller/usagereport_controller.go` — computes `marginal = activeEnergyKWh × ratePerKWh × pue / (tokens / 1e6)` when tokens served and energy > 0.
- `docs/cost-model.md` — worked example side-by-side with Anthropic Opus and GPT-5.4-nano showing why the two numbers diverge and what the honest reading is.

## Testing

- `TestSampler_SummarizeEnergy` validates rectangular integration against a hand-computed 300 W→10 W trace
- `TestSampler_SummarizeNoOverlapReturnsZero` covers the out-of-window case
- Existing utilization tests unchanged
- Full `go test ./...` green

## How to verify end-to-end

```bash
# After merge to main + operator upgrade:
kubectl get usagereports -o wide
# Expect new "$/MTok (marginal)" column; typically 10-1000x smaller than
# $/MTok at low utilization, converges at saturation.

kubectl get usagereport daily-report -o json | jq '.status | {
  amortized: .costPerMillionTokens,
  marginal: .marginalCostPerMillionTokens,
  activeEnergyKWh,
  utilizationPercent
}'
```

## Stacking

This PR targets `feat/utilization-percent` (#42) so the diff shows only the marginal-cost work. Once #42 merges to main, rebase this onto main and it'll be standalone.

Closes #38.