### PR TITLE
feat: add Apple Silicon (Metal) power collector for $/MTok on M-series Macs

### DIFF
--- a/charts/infercost/templates/deployment.yaml
+++ b/charts/infercost/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         {{- if .Values.dcgm.endpoint }}
         - --dcgm-endpoint={{ .Values.dcgm.endpoint }}
         {{- end }}
+        {{- if .Values.metal.endpoint }}
+        - --metal-endpoint={{ .Values.metal.endpoint }}
+        {{- end }}
         {{- if .Values.api.enabled }}
         - --api-bind-address=:{{ .Values.api.port }}
         {{- end }}

--- a/charts/infercost/values.yaml
+++ b/charts/infercost/values.yaml
@@ -57,7 +57,7 @@ controllerManager:
   affinity: {}
   env: []
 
-# DCGM Exporter configuration
+# DCGM Exporter configuration (NVIDIA hosts)
 dcgm:
   # DCGM exporter metrics endpoint URL.
   # Set to the DCGM exporter service in your cluster.
@@ -66,6 +66,22 @@ dcgm:
   # Examples:
   #   In-cluster: http://nvidia-dcgm-exporter.gpu-operator-resources.svc:9400/metrics
   #   NodePort:   http://<node-ip>:30940/metrics
+
+# LLMKube Metal Agent configuration (Apple Silicon hosts)
+# Apple Silicon has no DCGM equivalent; InferCost reads SoC power from the
+# LLMKube Metal Agent's apple_power_combined_watts gauge. Required for
+# real-time $/MTok on M-series Macs. CostProfiles with an Apple gpuModel
+# automatically use this endpoint when set; NVIDIA profiles continue to
+# use --dcgm-endpoint.
+metal:
+  # LLMKube Metal Agent /metrics endpoint URL.
+  # If empty, Apple-hardware CostProfiles fall back to TDP-based estimation.
+  endpoint: ""
+  # Examples:
+  #   Mac on the LAN: http://my-mac.local:9090/metrics
+  #   Tailscale:      http://100.64.0.10:9090/metrics
+  # Setup: install the LLMKube Metal Agent with --apple-power-enabled and the
+  # NOPASSWD sudoers entry from deployment/macos/sudoers.d/llmkube-powermetrics.
 
 # REST API configuration
 api:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var dcgmEndpoint string
+	var metalEndpoint string
 	var apiAddr string
 	var pricingFile string
 	var tlsOpts []func(*tls.Config)
@@ -76,6 +77,11 @@ func main() {
 	flag.StringVar(&dcgmEndpoint, "dcgm-endpoint", "",
 		"DCGM exporter metrics endpoint URL (e.g. http://nvidia-dcgm-exporter.gpu-operator-resources.svc:9400/metrics). "+
 			"If empty, falls back to TDP-based power estimation from CostProfile spec.")
+	flag.StringVar(&metalEndpoint, "metal-endpoint", "",
+		"LLMKube Metal Agent /metrics endpoint URL for Apple Silicon power data "+
+			"(e.g. http://my-mac.local:9090/metrics). Required for real-time $/MTok on M-series Macs; "+
+			"NVIDIA hosts continue to use --dcgm-endpoint. If both are set, CostProfiles "+
+			"with Apple gpuModel use Metal and others use DCGM.")
 	flag.StringVar(&pricingFile, "pricing-file", "",
 		"Path to a cloud-pricing.yaml override (same schema as config/pricing/cloud-pricing.yaml). "+
 			"If empty, the embedded default pricing catalog is used. Typical Helm value: mount a "+
@@ -227,23 +233,25 @@ func main() {
 	powerSampler := utilization.NewSampler()
 
 	if err := (&controller.CostProfileReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		ScrapeClient: scrapeClient,
-		DCGMEndpoint: dcgmEndpoint,
-		APIStore:     apiStore,
-		Sampler:      powerSampler,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		ScrapeClient:  scrapeClient,
+		DCGMEndpoint:  dcgmEndpoint,
+		MetalEndpoint: metalEndpoint,
+		APIStore:      apiStore,
+		Sampler:       powerSampler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "CostProfile")
 		os.Exit(1)
 	}
 	if err := (&controller.UsageReportReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		ScrapeClient: scrapeClient,
-		DCGMEndpoint: dcgmEndpoint,
-		APIStore:     apiStore,
-		Sampler:      powerSampler,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		ScrapeClient:  scrapeClient,
+		DCGMEndpoint:  dcgmEndpoint,
+		MetalEndpoint: metalEndpoint,
+		APIStore:      apiStore,
+		Sampler:       powerSampler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "UsageReport")
 		os.Exit(1)

--- a/config/samples/costprofiles/apple-m2-ultra.yaml
+++ b/config/samples/costprofiles/apple-m2-ultra.yaml
@@ -8,9 +8,19 @@ metadata:
     gpu.infercost.ai/model: m2-ultra
 spec:
   hardware:
-    # Apple Silicon has no DCGM exporter; InferCost falls back to TDP-based
-    # power estimation from the tdpWatts field. Real-time power metrics will
-    # require a Metal-aware exporter (tracked on the roadmap).
+    # Real-time SoC power available — install the LLMKube Metal Agent with
+    # --apple-power-enabled and pass --metal-endpoint=http://<host>:9090/metrics
+    # to InferCost. With the Metal endpoint set, this profile reads its
+    # currentPowerDrawWatts from the agent's apple_power_combined_watts gauge
+    # (CPU + GPU + ANE). Without it, the tdpWatts below is used as fallback.
+    #
+    # Setup notes:
+    #   - The agent ships a NOPASSWD sudoers entry for /usr/bin/powermetrics
+    #     pinned to the exact argv it uses; install it via the install snippet
+    #     in deployment/macos/README.md of github.com/defilantech/llmkube.
+    #   - Do NOT pass --powermetrics-bin=<custom> to the agent — Phase 1
+    #     security hardening refuses non-default paths and you'll see this
+    #     CostProfile sit at MetalSamplerOff.
     gpuModel: "Apple M2 Ultra"
     gpuCount: 1                       # Unified SoC counts as one "GPU"
     # Purchase price: Mac Studio M2 Ultra (192GB unified memory): ~$6,800 MSRP.

--- a/config/samples/costprofiles/apple-m5-max.yaml
+++ b/config/samples/costprofiles/apple-m5-max.yaml
@@ -24,12 +24,12 @@ spec:
     # ~42 W combined (CPU + GPU + ANE). 90 W TDP is a safe fallback that
     # bounds the worst case (sustained CPU + GPU + display + chargers).
     tdpWatts: 90
+  electricity:
+    ratePerKWh: 0.15
+    pueFactor: 1.0                    # Single laptop, no datacenter overhead
     # Idle threshold: M-series SoCs idle around 5-8 W, well below 20% of
     # TDP. Set explicitly so the utilization sampler doesn't overcount idle
     # time as active.
     idleWattsThreshold: 12
-  electricity:
-    ratePerKWh: 0.15
-    pueFactor: 1.0                    # Single laptop, no datacenter overhead
   nodeSelector:
     kubernetes.io/hostname: macbook-m5max

--- a/config/samples/costprofiles/apple-m5-max.yaml
+++ b/config/samples/costprofiles/apple-m5-max.yaml
@@ -1,0 +1,35 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: apple-m5-max
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: apple
+    gpu.infercost.ai/model: m5-max
+spec:
+  hardware:
+    # MacBook Pro M5 Max (40-core GPU, 128GB unified memory). Real-time SoC
+    # power available via the LLMKube Metal Agent's
+    # apple_power_combined_watts gauge — install with --apple-power-enabled
+    # and pass --metal-endpoint=http://<host>:9090/metrics to InferCost.
+    # See apple-m2-ultra.yaml for sudoers / setup notes.
+    gpuModel: "Apple M5 Max"
+    gpuCount: 1                       # Unified SoC counts as one "GPU"
+    # Purchase price: MBP 16" M5 Max (40-core GPU, 128GB unified): ~$4,500.
+    # The whole laptop is the GPU here.
+    purchasePriceUSD: 4500
+    amortizationYears: 3              # Laptops cycle faster than desktops
+    maintenancePercentPerYear: 0.02
+    # Sustained system power on M5 Max under inference load measured at
+    # ~42 W combined (CPU + GPU + ANE). 90 W TDP is a safe fallback that
+    # bounds the worst case (sustained CPU + GPU + display + chargers).
+    tdpWatts: 90
+    # Idle threshold: M-series SoCs idle around 5-8 W, well below 20% of
+    # TDP. Set explicitly so the utilization sampler doesn't overcount idle
+    # time as active.
+    idleWattsThreshold: 12
+  electricity:
+    ratePerKWh: 0.15
+    pueFactor: 1.0                    # Single laptop, no datacenter overhead
+  nodeSelector:
+    kubernetes.io/hostname: macbook-m5max

--- a/internal/controller/costprofile_controller.go
+++ b/internal/controller/costprofile_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -60,13 +61,29 @@ const (
 	ReasonDCGMNoReadings    = "DCGMNoReadings"
 )
 
+// Metal status reporting on CostProfile.status.conditions. Apple Silicon
+// hosts have no DCGM equivalent; InferCost reads SoC power from the LLMKube
+// Metal Agent's apple_power_*_watts gauges (see defilantech/llmkube). We use
+// a separate condition type rather than overloading DCGMReachable so an
+// operator inspecting a Mac CostProfile doesn't see a confusing "DCGM
+// unreachable" message when DCGM was never the right tool.
+const (
+	ConditionMetalReachable = "MetalReachable"
+
+	ReasonMetalHealthy       = "MetalHealthy"
+	ReasonMetalNotConfigured = "MetalNotConfigured"
+	ReasonMetalScrapeError   = "MetalScrapeError"
+	ReasonMetalSamplerOff    = "MetalSamplerOff"
+)
+
 // CostProfileReconciler reconciles a CostProfile object.
 type CostProfileReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	ScrapeClient *scraper.Client
-	DCGMEndpoint string // DCGM exporter service URL
-	APIStore     *internalapi.Store
+	Scheme        *runtime.Scheme
+	ScrapeClient  *scraper.Client
+	DCGMEndpoint  string // DCGM exporter service URL (NVIDIA path)
+	MetalEndpoint string // LLMKube Metal Agent /metrics URL (Apple Silicon path)
+	APIStore      *internalapi.Store
 
 	// Sampler records per-tick GPU power draw so UsageReports can answer
 	// "what fraction of this period was the GPU actually working?". Shared
@@ -109,10 +126,12 @@ func (r *CostProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		PUEFactor:                 profile.Spec.Electricity.PUEFactor,
 	}
 
-	// 2. Scrape DCGM for real-time GPU power draw, and surface any fallback
-	// path as a DCGMReachable condition so operators can tell at a glance
-	// whether their dashboards will show real-time load or a flat TDP estimate.
-	totalPowerW, dcgmCondition := r.readDCGMPower(ctx, profile)
+	// 2. Scrape real-time power draw from whichever backend is configured for
+	// this profile (DCGM for NVIDIA, the LLMKube Metal Agent for Apple
+	// Silicon, TDP fallback otherwise). Both paths surface a status condition
+	// so operators can tell at a glance whether their dashboards show
+	// real-time load or a flat TDP estimate.
+	totalPowerW, powerCondition := r.readPower(ctx, profile)
 
 	// 2a. Record the sample for utilization accounting. Computes the active
 	// threshold from spec with a sensible default when the operator hasn't
@@ -157,8 +176,8 @@ func (r *CostProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Message:            fmt.Sprintf("Hourly cost: $%.4f (amort: $%.4f, elec: $%.4f)", total, amort, elec),
 		LastTransitionTime: now,
 	})
-	dcgmCondition.LastTransitionTime = now
-	meta.SetStatusCondition(&profile.Status.Conditions, dcgmCondition)
+	powerCondition.LastTransitionTime = now
+	meta.SetStatusCondition(&profile.Status.Conditions, powerCondition)
 
 	if err := r.Status().Update(ctx, &profile); err != nil {
 		log.Error(err, "failed to update CostProfile status")
@@ -408,6 +427,92 @@ func (r *CostProfileReconciler) readDCGMPower(ctx context.Context, profile finop
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonDCGMHealthy,
 		Message: fmt.Sprintf("DCGM healthy at %s (%.0fW current draw).", r.DCGMEndpoint, totalPowerW),
+	}
+}
+
+// readPower picks the right power source for this CostProfile. Apple
+// hardware (gpuModel "Apple …") with a configured Metal endpoint goes through
+// the LLMKube Metal Agent path; everything else falls through to the existing
+// DCGM path (which itself handles "no endpoint configured" via TDP fallback).
+//
+// We discriminate on gpuModel rather than adding a vendor field to the CRD
+// because gpuModel is already the human-readable identifier and Apple's
+// naming ("Apple M5 Max", "Apple M2 Ultra") is consistent and unique.
+func (r *CostProfileReconciler) readPower(ctx context.Context, profile finopsv1alpha1.CostProfile) (float64, metav1.Condition) {
+	if r.MetalEndpoint != "" && looksApple(profile.Spec.Hardware.GPUModel) {
+		return r.readMetalPower(ctx, profile)
+	}
+	return r.readDCGMPower(ctx, profile)
+}
+
+// looksApple returns true when the GPU model name identifies an Apple Silicon
+// SoC. Substring match keeps it tolerant of formatting variation ("Apple M5
+// Max", "Apple M2 Ultra", "apple m3 pro") without requiring operators to
+// learn a magic string.
+func looksApple(gpuModel string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(gpuModel)), "apple ")
+}
+
+// readMetalPower returns the current SoC power draw from the LLMKube Metal
+// Agent's apple_power_combined_watts gauge along with a MetalReachable
+// condition that describes how the number was obtained. Mirrors the
+// every-path-emits-a-condition contract of readDCGMPower so silent fallbacks
+// don't hide misconfiguration.
+func (r *CostProfileReconciler) readMetalPower(ctx context.Context, profile finopsv1alpha1.CostProfile) (float64, metav1.Condition) {
+	log := logf.FromContext(ctx)
+
+	if r.MetalEndpoint == "" {
+		power := r.fallbackPowerDraw(profile)
+		return power, metav1.Condition{
+			Type:    ConditionMetalReachable,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMetalNotConfigured,
+			Message: fmt.Sprintf("Metal endpoint not set; using TDP fallback (%.0fW). Install the LLMKube Metal Agent with --apple-power-enabled and pass --metal-endpoint to InferCost.", power),
+		}
+	}
+
+	reading, err := scraper.ScrapeApplePower(ctx, r.ScrapeClient, r.MetalEndpoint)
+	if err != nil {
+		log.Error(err, "failed to scrape Metal agent, falling back to TDP", "endpoint", r.MetalEndpoint)
+		power := r.fallbackPowerDraw(profile)
+		return power, metav1.Condition{
+			Type:    ConditionMetalReachable,
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMetalScrapeError,
+			Message: fmt.Sprintf("Metal scrape failed at %s: %v. Using TDP fallback (%.0fW).", r.MetalEndpoint, err, power),
+		}
+	}
+
+	// CombinedW is zero when the agent is reachable but the powermetrics
+	// sampler isn't running (operator forgot --apple-power-enabled, or the
+	// NOPASSWD sudoers entry isn't installed, or they overrode
+	// --powermetrics-bin which the agent now refuses). Distinguish this
+	// from a network failure so the condition reason can point at the
+	// actual fix.
+	if reading.CombinedW == 0 {
+		power := r.fallbackPowerDraw(profile)
+		return power, metav1.Condition{
+			Type:    ConditionMetalReachable,
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonMetalSamplerOff,
+			Message: fmt.Sprintf("Metal agent reachable at %s but apple_power_combined_watts is 0. Verify --apple-power-enabled is set and /etc/sudoers.d/llmkube-powermetrics is installed. Using TDP fallback (%.0fW).", r.MetalEndpoint, power),
+		}
+	}
+
+	// Publish the SoC-wide combined draw against the per-profile gauge that
+	// already feeds the cost dashboard. Use the profile name as the "node"
+	// label since Apple agents are single-host (no multi-GPU sharding).
+	node := profile.Spec.NodeSelector["kubernetes.io/hostname"]
+	if node == "" {
+		node = profile.Name
+	}
+	infercostmetrics.GPUPowerWatts.WithLabelValues(profile.Name, node, "soc").Set(reading.CombinedW)
+
+	return reading.CombinedW, metav1.Condition{
+		Type:    ConditionMetalReachable,
+		Status:  metav1.ConditionTrue,
+		Reason:  ReasonMetalHealthy,
+		Message: fmt.Sprintf("Metal agent healthy at %s (%.1fW combined; gpu=%.1f cpu=%.1f ane=%.1f).", r.MetalEndpoint, reading.CombinedW, reading.GPUW, reading.CPUW, reading.ANEW),
 	}
 }
 

--- a/internal/controller/costprofile_metal_test.go
+++ b/internal/controller/costprofile_metal_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
+	"github.com/defilantech/infercost/internal/scraper"
+)
+
+// appleProfile mirrors testProfile but for an Apple Silicon host. The
+// gpuModel is what looksApple matches on, so this is the discriminator
+// the dispatcher uses to pick Metal over DCGM.
+func appleProfile(tdp *int32) finopsv1alpha1.CostProfile {
+	return finopsv1alpha1.CostProfile{
+		Spec: finopsv1alpha1.CostProfileSpec{
+			Hardware: finopsv1alpha1.HardwareSpec{
+				GPUModel: "Apple M5 Max",
+				GPUCount: 1,
+				TDPWatts: tdp,
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": "m5-max-laptop",
+			},
+		},
+	}
+}
+
+const metalAgentMetricsHealthy = `# HELP llmkube_metal_agent_apple_power_combined_watts Combined CPU + GPU + ANE package power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_combined_watts gauge
+llmkube_metal_agent_apple_power_combined_watts 42.5
+# HELP llmkube_metal_agent_apple_power_gpu_watts GPU subsystem power.
+# TYPE llmkube_metal_agent_apple_power_gpu_watts gauge
+llmkube_metal_agent_apple_power_gpu_watts 31.2
+# HELP llmkube_metal_agent_apple_power_cpu_watts CPU subsystem power.
+# TYPE llmkube_metal_agent_apple_power_cpu_watts gauge
+llmkube_metal_agent_apple_power_cpu_watts 11.3
+# HELP llmkube_metal_agent_apple_power_ane_watts ANE power.
+# TYPE llmkube_metal_agent_apple_power_ane_watts gauge
+llmkube_metal_agent_apple_power_ane_watts 0
+`
+
+const metalAgentMetricsSamplerOff = `# HELP llmkube_metal_agent_apple_power_combined_watts Combined CPU + GPU + ANE package power in watts.
+# TYPE llmkube_metal_agent_apple_power_combined_watts gauge
+llmkube_metal_agent_apple_power_combined_watts 0
+`
+
+func TestReadMetalPower_EndpointNotConfigured(t *testing.T) {
+	tdp := int32(90)
+	r := &CostProfileReconciler{MetalEndpoint: "", ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readMetalPower(context.Background(), appleProfile(&tdp))
+
+	if want := float64(90); power != want {
+		t.Errorf("power = %.0f, want %.0f (TDP fallback)", power, want)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonMetalNotConfigured {
+		t.Errorf("condition = %s/%s, want False/MetalNotConfigured", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "--apple-power-enabled") {
+		t.Errorf("message should point at the agent flag: %q", cond.Message)
+	}
+}
+
+func TestReadMetalPower_EndpointUnreachable(t *testing.T) {
+	tdp := int32(90)
+	r := &CostProfileReconciler{
+		MetalEndpoint: "http://127.0.0.1:1/metrics",
+		ScrapeClient:  scraper.NewClient(500 * time.Millisecond),
+	}
+
+	power, cond := r.readMetalPower(context.Background(), appleProfile(&tdp))
+
+	if want := float64(90); power != want {
+		t.Errorf("power = %.0f, want %.0f (TDP fallback)", power, want)
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != ReasonMetalScrapeError {
+		t.Errorf("condition = %s/%s, want False/MetalScrapeError", cond.Status, cond.Reason)
+	}
+}
+
+func TestReadMetalPower_SamplerOff(t *testing.T) {
+	// Agent reachable but powermetrics sampler disabled — operator forgot
+	// --apple-power-enabled or sudoers entry. The condition reason must
+	// distinguish this from a network error so docs can guide the fix.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metalAgentMetricsSamplerOff))
+	}))
+	defer server.Close()
+
+	tdp := int32(90)
+	r := &CostProfileReconciler{MetalEndpoint: server.URL, ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readMetalPower(context.Background(), appleProfile(&tdp))
+
+	if want := float64(90); power != want {
+		t.Errorf("power = %.0f, want %.0f (TDP fallback when sampler off)", power, want)
+	}
+	if cond.Status != metav1.ConditionUnknown || cond.Reason != ReasonMetalSamplerOff {
+		t.Errorf("condition = %s/%s, want Unknown/MetalSamplerOff", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "sudoers") {
+		t.Errorf("message should mention sudoers as likely cause: %q", cond.Message)
+	}
+}
+
+func TestReadMetalPower_HealthyReadings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metalAgentMetricsHealthy))
+	}))
+	defer server.Close()
+
+	tdp := int32(90)
+	r := &CostProfileReconciler{MetalEndpoint: server.URL, ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	power, cond := r.readMetalPower(context.Background(), appleProfile(&tdp))
+
+	if power != 42.5 {
+		t.Errorf("power = %.1f, want 42.5 (combined gauge)", power)
+	}
+	if cond.Status != metav1.ConditionTrue || cond.Reason != ReasonMetalHealthy {
+		t.Errorf("condition = %s/%s, want True/MetalHealthy", cond.Status, cond.Reason)
+	}
+	// The status message should expose the per-component breakdown so
+	// `kubectl describe costprofile` is useful for debugging dashboards.
+	for _, want := range []string{"42.5", "gpu=31.2", "cpu=11.3", "ane=0.0"} {
+		if !strings.Contains(cond.Message, want) {
+			t.Errorf("message missing %q: %q", want, cond.Message)
+		}
+	}
+}
+
+// readPower is the dispatcher. These cover the routing decisions; the actual
+// scrape paths are covered above and in costprofile_dcgm_test.go.
+
+func TestReadPower_AppleProfileWithMetalEndpointUsesMetal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metalAgentMetricsHealthy))
+	}))
+	defer server.Close()
+
+	tdp := int32(90)
+	r := &CostProfileReconciler{
+		MetalEndpoint: server.URL,
+		// DCGM endpoint is also set; dispatcher must not pick it for an Apple profile.
+		DCGMEndpoint: "http://should-not-be-called.invalid",
+		ScrapeClient: scraper.NewClient(2 * time.Second),
+	}
+
+	_, cond := r.readPower(context.Background(), appleProfile(&tdp))
+	if cond.Type != ConditionMetalReachable {
+		t.Errorf("expected MetalReachable condition for Apple profile, got %q", cond.Type)
+	}
+}
+
+func TestReadPower_NVIDIAProfileWithBothEndpointsUsesDCGM(t *testing.T) {
+	// NVIDIA profile + both endpoints set: dispatcher must pick DCGM. We
+	// verify by checking the condition type — readDCGMPower will return a
+	// scrape-error condition because the endpoint is bogus, but the *type*
+	// proves which path was taken.
+	tdp := int32(180)
+	r := &CostProfileReconciler{
+		MetalEndpoint: "http://should-not-be-called.invalid",
+		DCGMEndpoint:  "http://127.0.0.1:1/metrics",
+		ScrapeClient:  scraper.NewClient(500 * time.Millisecond),
+	}
+
+	_, cond := r.readPower(context.Background(), testProfile(&tdp))
+	if cond.Type != ConditionDCGMReachable {
+		t.Errorf("expected DCGMReachable condition for NVIDIA profile, got %q", cond.Type)
+	}
+}
+
+func TestReadPower_AppleProfileWithoutMetalEndpointFallsThroughToDCGM(t *testing.T) {
+	// Apple profile but operator hasn't set --metal-endpoint. The dispatcher
+	// falls through to readDCGMPower, which itself does TDP fallback when
+	// DCGM is also unset. This isn't ideal UX (the operator probably wants
+	// MetalNotConfigured guidance, not DCGM guidance) but it's the safe
+	// behavior — the alternative would be silently returning zero power.
+	// Documented in the apple-m2-ultra.yaml sample.
+	tdp := int32(90)
+	r := &CostProfileReconciler{ScrapeClient: scraper.NewClient(2 * time.Second)}
+
+	_, cond := r.readPower(context.Background(), appleProfile(&tdp))
+	if cond.Type != ConditionDCGMReachable {
+		t.Errorf("expected DCGMReachable (fallback path) when neither endpoint is set, got %q", cond.Type)
+	}
+}
+
+func TestLooksApple(t *testing.T) {
+	cases := map[string]bool{
+		"Apple M5 Max":               true,
+		"Apple M2 Ultra":             true,
+		"apple m3 pro":               true,
+		"  Apple M4  ":               true,
+		"NVIDIA GeForce RTX 5060 Ti": false,
+		"AMD Radeon Pro W7900":       false,
+		"Apple":                      false, // no trailing space → no model name
+		"":                           false,
+		"M5 Max":                     false, // missing vendor prefix
+	}
+	for in, want := range cases {
+		if got := looksApple(in); got != want {
+			t.Errorf("looksApple(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/controller/usagereport_controller.go
+++ b/internal/controller/usagereport_controller.go
@@ -46,10 +46,11 @@ const (
 // UsageReportReconciler reconciles a UsageReport object
 type UsageReportReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	ScrapeClient *scraper.Client
-	DCGMEndpoint string
-	APIStore     *internalapi.Store
+	Scheme        *runtime.Scheme
+	ScrapeClient  *scraper.Client
+	DCGMEndpoint  string
+	MetalEndpoint string // LLMKube Metal Agent /metrics URL (Apple Silicon path)
+	APIStore      *internalapi.Store
 
 	// Sampler is the same *utilization.Sampler the CostProfile reconciler
 	// writes power samples to. Used to compute activeHours / totalHours /

--- a/internal/scraper/metal.go
+++ b/internal/scraper/metal.go
@@ -1,0 +1,59 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+)
+
+// Apple Silicon power-gauge metric names exposed by the LLMKube Metal Agent
+// when started with --apple-power-enabled. Source: defilantech/llmkube
+// pkg/agent/agentmetrics.go. The gauges are unlabeled — one float per
+// metric — because powermetrics reports a single SoC-wide reading.
+const (
+	ApplePowerCombinedMetric = "llmkube_metal_agent_apple_power_combined_watts"
+	ApplePowerGPUMetric      = "llmkube_metal_agent_apple_power_gpu_watts"
+	ApplePowerCPUMetric      = "llmkube_metal_agent_apple_power_cpu_watts"
+	ApplePowerANEMetric      = "llmkube_metal_agent_apple_power_ane_watts"
+)
+
+// ApplePowerReading is one snapshot of Apple Silicon SoC power, in watts.
+// Combined is what `Sampler.Record` should consume because it includes the
+// full CPU + GPU + ANE package draw — the same scope DCGM reports for an
+// NVIDIA card. The component fields are populated for visibility (dashboards,
+// debugging) but cost math should use Combined.
+type ApplePowerReading struct {
+	CombinedW float64
+	GPUW      float64
+	CPUW      float64
+	ANEW      float64
+}
+
+// ScrapeApplePower fetches the LLMKube Metal Agent's apple_power_*_watts
+// gauges from a Prometheus-format /metrics endpoint and returns the most
+// recent sample. Returns a zero-valued reading (not an error) when the
+// endpoint is reachable but the agent isn't publishing power data — that
+// happens when the operator forgot to set --apple-power-enabled or
+// installed the sudoers entry incorrectly. The caller distinguishes
+// "endpoint down" (error) from "sampler off" (zero combined value) so the
+// status condition can carry an actionable reason.
+func ScrapeApplePower(ctx context.Context, client *Client, endpoint string) (ApplePowerReading, error) {
+	samples, err := client.Scrape(ctx, endpoint)
+	if err != nil {
+		return ApplePowerReading{}, fmt.Errorf("scraping Metal agent: %w", err)
+	}
+
+	var r ApplePowerReading
+	for _, s := range FilterByName(samples, ApplePowerCombinedMetric) {
+		r.CombinedW = s.Value
+	}
+	for _, s := range FilterByName(samples, ApplePowerGPUMetric) {
+		r.GPUW = s.Value
+	}
+	for _, s := range FilterByName(samples, ApplePowerCPUMetric) {
+		r.CPUW = s.Value
+	}
+	for _, s := range FilterByName(samples, ApplePowerANEMetric) {
+		r.ANEW = s.Value
+	}
+	return r, nil
+}

--- a/internal/scraper/metal_test.go
+++ b/internal/scraper/metal_test.go
@@ -1,0 +1,154 @@
+package scraper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// metalMetricsText is what the LLMKube Metal Agent's /metrics endpoint emits
+// when --apple-power-enabled is set and powermetrics is running. Captured
+// verbatim from a real M5 Max session so the test fails loudly if the agent
+// renames or reshapes a gauge in a future release.
+const metalMetricsText = `# HELP llmkube_metal_agent_apple_power_combined_watts Combined CPU + GPU + ANE package power in watts from macOS powermetrics. Zero unless the agent is run with --apple-power-enabled and a NOPASSWD sudoers entry for /usr/bin/powermetrics is installed.
+# TYPE llmkube_metal_agent_apple_power_combined_watts gauge
+llmkube_metal_agent_apple_power_combined_watts 42.318
+# HELP llmkube_metal_agent_apple_power_gpu_watts GPU subsystem power in watts from macOS powermetrics. Zero unless --apple-power-enabled.
+# TYPE llmkube_metal_agent_apple_power_gpu_watts gauge
+llmkube_metal_agent_apple_power_gpu_watts 31.205
+# HELP llmkube_metal_agent_apple_power_cpu_watts CPU subsystem power in watts from macOS powermetrics. Zero unless --apple-power-enabled.
+# TYPE llmkube_metal_agent_apple_power_cpu_watts gauge
+llmkube_metal_agent_apple_power_cpu_watts 11.113
+# HELP llmkube_metal_agent_apple_power_ane_watts Apple Neural Engine power in watts from macOS powermetrics. Zero unless --apple-power-enabled.
+# TYPE llmkube_metal_agent_apple_power_ane_watts gauge
+llmkube_metal_agent_apple_power_ane_watts 0
+`
+
+// metalMetricsTextSamplerDisabled is what the agent emits when
+// --apple-power-enabled is false: the gauges are still registered but read
+// as zero. InferCost must distinguish this from an unreachable endpoint so
+// the status condition can recommend "enable the sampler" rather than
+// "check the network".
+const metalMetricsTextSamplerDisabled = `# HELP llmkube_metal_agent_apple_power_combined_watts Combined CPU + GPU + ANE package power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_combined_watts gauge
+llmkube_metal_agent_apple_power_combined_watts 0
+# HELP llmkube_metal_agent_apple_power_gpu_watts GPU subsystem power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_gpu_watts gauge
+llmkube_metal_agent_apple_power_gpu_watts 0
+# HELP llmkube_metal_agent_apple_power_cpu_watts CPU subsystem power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_cpu_watts gauge
+llmkube_metal_agent_apple_power_cpu_watts 0
+# HELP llmkube_metal_agent_apple_power_ane_watts Apple Neural Engine power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_ane_watts gauge
+llmkube_metal_agent_apple_power_ane_watts 0
+`
+
+func TestScrapeApplePower(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metalMetricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	r, err := ScrapeApplePower(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeApplePower returned error: %v", err)
+	}
+
+	if r.CombinedW != 42.318 {
+		t.Errorf("CombinedW = %v, want 42.318", r.CombinedW)
+	}
+	if r.GPUW != 31.205 {
+		t.Errorf("GPUW = %v, want 31.205", r.GPUW)
+	}
+	if r.CPUW != 11.113 {
+		t.Errorf("CPUW = %v, want 11.113", r.CPUW)
+	}
+	if r.ANEW != 0 {
+		t.Errorf("ANEW = %v, want 0", r.ANEW)
+	}
+}
+
+func TestScrapeApplePower_SamplerDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metalMetricsTextSamplerDisabled))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	r, err := ScrapeApplePower(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeApplePower returned error: %v", err)
+	}
+	// Sampler-off must be a *successful* scrape returning zeros, not an error.
+	// The reconciler uses CombinedW == 0 as the "agent reachable but sampler
+	// off" signal to emit a different condition reason than a network failure.
+	if r.CombinedW != 0 {
+		t.Errorf("expected CombinedW=0 when sampler disabled, got %v", r.CombinedW)
+	}
+}
+
+func TestScrapeApplePower_NoMetrics(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	r, err := ScrapeApplePower(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeApplePower returned error: %v", err)
+	}
+	if r != (ApplePowerReading{}) {
+		t.Errorf("expected zero reading for empty metrics, got %+v", r)
+	}
+}
+
+func TestScrapeApplePower_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	_, err := ScrapeApplePower(context.Background(), client, server.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 503 response")
+	}
+}
+
+// TestScrapeApplePower_OnlyCombinedPresent guards the case where a future
+// LLMKube release stops emitting one of the component gauges. The scraper
+// must keep working from whatever it can find — Combined is the only field
+// the cost math needs.
+func TestScrapeApplePower_OnlyCombinedPresent(t *testing.T) {
+	metricsText := `# HELP llmkube_metal_agent_apple_power_combined_watts Combined CPU + GPU + ANE package power in watts from macOS powermetrics.
+# TYPE llmkube_metal_agent_apple_power_combined_watts gauge
+llmkube_metal_agent_apple_power_combined_watts 17.5
+`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metricsText))
+	}))
+	defer server.Close()
+
+	client := NewClient(5 * time.Second)
+	r, err := ScrapeApplePower(context.Background(), client, server.URL)
+	if err != nil {
+		t.Fatalf("ScrapeApplePower returned error: %v", err)
+	}
+	if r.CombinedW != 17.5 {
+		t.Errorf("CombinedW = %v, want 17.5", r.CombinedW)
+	}
+	if r.GPUW != 0 || r.CPUW != 0 || r.ANEW != 0 {
+		t.Errorf("expected zero component readings when only combined is published, got %+v", r)
+	}
+}


### PR DESCRIPTION
Closes #46.

## Summary

InferCost's existing power-data path reads NVIDIA GPU power from the DCGM exporter. macOS has no DCGM equivalent, so every Apple Silicon CostProfile silently fell back to TDP estimation — fine for order-of-magnitude numbers, useless for tracking dynamic load.

This adds a parallel **Metal collector** that scrapes the LLMKube Metal Agent's `apple_power_*_watts` gauges (defilantech/llmkube#335 / [PR #334](https://github.com/defilantech/LLMKube/pull/334)). The agent ships those gauges from a sudo'd `powermetrics` subprocess. The combined CPU + GPU + ANE watts is the right scope to feed into the existing cost calculation — exactly mirroring what DCGM reports for an NVIDIA card.

## Architecture

- **`internal/scraper/metal.go`**: `ScrapeApplePower` mirrors `ScrapeDCGM`. Returns `ApplePowerReading{Combined, GPU, CPU, ANE}` — single-row return because the gauges are unlabeled (no per-GPU/per-pod cardinality on a Mac).
- **`internal/controller/costprofile_controller.go`**: `readMetalPower` follows the same every-path-emits-a-condition contract as `readDCGMPower`. New `readPower` dispatcher (10 lines) keys off `MetalEndpoint != \"\" && looksApple(gpuModel)` to pick Metal vs DCGM.
- **New `ConditionMetalReachable`** with reasons `MetalHealthy / MetalNotConfigured / MetalScrapeError / MetalSamplerOff` — operators on a Mac don't see a confusing \"DCGM unreachable\" message when DCGM was never the right tool.
- **The `MetalSamplerOff` path is the important one**: agent reachable but `apple_power_combined_watts` is zero → operator forgot `--apple-power-enabled`, the sudoers entry is missing, or they overrode `--powermetrics-bin` (which the agent's Phase 1 security hardening now refuses). The condition message names all three.

## Plumbing

- `cmd/main.go`: new `--metal-endpoint` flag, plumbed to both reconcilers.
- `internal/controller/usagereport_controller.go`: `MetalEndpoint` field added for symmetry. Currently unused at runtime (UsageReport reads from profile status + the shared `Sampler`), but keeps a future direct-scrape variant a one-liner.
- `charts/infercost/values.yaml` + `templates/deployment.yaml`: parallel `metal:` block next to `dcgm:`.
- `config/samples/costprofiles/apple-m5-max.yaml` (new): real M5 Max numbers — \$4500 / 3yr amortization, 90W TDP fallback, `idleWattsThreshold: 12` so the M-series ~6W idle floor doesn't register as active.
- `config/samples/costprofiles/apple-m2-ultra.yaml`: replace the \"roadmap\" comment with actual setup steps + a callout warning operators not to override the agent's `--powermetrics-bin`.

## Tests

- **`internal/scraper/metal_test.go`** (5 cases): happy path, sampler disabled (zeros), empty body, HTTP 503, only-combined-present. Captured fixture matches what a real M5 Max emits.
- **`internal/controller/costprofile_metal_test.go`** (8 cases): 4 `readMetalPower` paths × condition assertions + 3 `readPower` dispatcher cases + `TestLooksApple` table. Dispatcher tests use a sentinel `should-not-be-called.invalid` endpoint on the wrong path so a routing regression fails loudly.
- All existing DCGM tests untouched and still passing — the dispatcher refactor is additive.

## Verification

```
go test ./...                                            # all green
helm template charts/infercost --set metal.endpoint=http://x:9090/metrics
  | grep metal-endpoint
  → - --metal-endpoint=http://x:9090/metrics             # rendered correctly
```

## Test plan

- [x] Unit tests for `ScrapeApplePower` (5 cases)
- [x] Unit tests for `readMetalPower` + `readPower` dispatcher (8 cases)
- [x] Existing `readDCGMPower` tests still pass (regression guard)
- [x] `helm template` emits `--metal-endpoint` arg when set
- [x] `go build ./...` and `go vet ./...` clean
- [x] **Manual E2E on M5 Max**: install LLMKube Metal Agent v0.7.x with `--apple-power-enabled`, install sudoers entry, deploy InferCost via Helm with `metal.endpoint=http://localhost:9090/metrics`, apply `apple-m5-max.yaml`, verify `kubectl get costprofile apple-m5-max -o yaml` shows `currentPowerDrawWatts: ~42` and `MetalReachable=True/MetalHealthy`. Then start inference traffic and watch `infercost_cost_per_million_tokens_usd` populate.

## Follow-ups (separate PRs)

- Auto-discovery of LLMKube Metal Agents via label selector (drop the explicit `--metal-endpoint` flag for fleet deployments)
- A `dashboards/apple-silicon.json` Grafana board fed from the new gauges
- `docs/apple-silicon.md` one-pager linking from the sample comments