### PR TITLE
feat(samples): add NVIDIA B200 HGX CostProfile (datacenter Blackwell)

### DIFF
--- a/config/samples/costprofiles/README.md
+++ b/config/samples/costprofiles/README.md
@@ -19,6 +19,7 @@ inline so you can adjust the numbers to your actual purchase.
 
 | File | GPU | Typical use |
 |------|-----|-------------|
+| [nvidia-b200-hgx.yaml](nvidia-b200-hgx.yaml) | B200 HGX 180GB (8-GPU chassis) | Frontier inference + training, datacenter Blackwell |
 | [nvidia-h100-sxm5.yaml](nvidia-h100-sxm5.yaml) | H100 SXM5 80GB | Training + large-model inference |
 | [nvidia-a100-80gb.yaml](nvidia-a100-80gb.yaml) | A100 80GB | Large-model inference |
 | [nvidia-a100-40gb.yaml](nvidia-a100-40gb.yaml) | A100 40GB | Mid-model inference |

--- a/config/samples/costprofiles/nvidia-b200-hgx.yaml
+++ b/config/samples/costprofiles/nvidia-b200-hgx.yaml
@@ -1,0 +1,46 @@
+apiVersion: finops.infercost.ai/v1alpha1
+kind: CostProfile
+metadata:
+  name: nvidia-b200-hgx
+  labels:
+    app.kubernetes.io/name: infercost
+    gpu.infercost.ai/vendor: nvidia
+    gpu.infercost.ai/model: b200-hgx-180gb
+spec:
+  hardware:
+    gpuModel: "NVIDIA B200 (HGX)"
+    # 8-GPU HGX B200 baseboard is the canonical datacenter form factor.
+    # Single-GPU PCIe SKUs exist but the 8-GPU NVLink5 / NVSwitch5 chassis
+    # is what most enterprises buy.
+    gpuCount: 8
+    # Purchase price: real procurement quotes vary widely depending on
+    # configuration (HBM size: 180 GB vs 192 GB), liquid vs air cooling,
+    # CPU + memory + storage in the chassis. Mid-2026 list pricing for a
+    # full DGX B200 chassis (8x B200 + dual Xeon + 2 TB DRAM + NVMe) is
+    # in the $450k-$650k range. $500k is a defensible round number for
+    # the bare HGX B200 board + reasonable host. Update with your actual
+    # PO once procurement closes; the per-token math moves with it.
+    purchasePriceUSD: 500000
+    amortizationYears: 3            # Datacenter compute typically 3 yrs
+    maintenancePercentPerYear: 0.10 # NVIDIA Enterprise support contract typical
+    # Per-GPU TDP. B200 sticker TDP is 1000 W; some liquid-cooled SKUs
+    # advertise up to 1200 W under sustained load. 1000 W is the
+    # accounting baseline; bump to 1200 if your chassis is liquid-cooled
+    # and your CostProfile is consistently under-attributing power.
+    tdpWatts: 1000
+  electricity:
+    ratePerKWh: 0.12       # US commercial average; industrial / colo rates vary
+    pueFactor: 1.4         # Typical modern data center PUE; 1.2-1.3 for hyperscale
+  nodeSelector:
+    # Match the node where your B200 workloads run. Common options:
+    #   kubernetes.io/hostname: <node-name>
+    #   nvidia.com/gpu.product: NVIDIA-B200
+    #   nvidia.com/gpu.family: blackwell
+    kubernetes.io/hostname: b200-node-01
+
+  # Note: at 8x B200 @ 1000 W = 8 kW just for GPUs. Full HGX B200 chassis
+  # (CPU + memory + cooling overhead) draws ~14 kW. Plan PDU + facility
+  # cooling capacity accordingly. dcgm-exporter 4.5+ exposes per-GPU
+  # power counters that drive currentPowerDrawWatts in the controller's
+  # status; install that version to get real-time accounting instead of
+  # tdpWatts fallback.


### PR DESCRIPTION
## Summary

Adds a CostProfile sample for the NVIDIA B200 in 8-GPU HGX chassis form, the canonical datacenter Blackwell SKU. Closes the gap in the sample library now that Blackwell is shipping into customer datacenters.

## What's in this PR

- `config/samples/costprofiles/nvidia-b200-hgx.yaml`: new sample with conservative mid-2026 numbers and inline notes for procurement adjustments
- `config/samples/costprofiles/README.md`: adds the new entry to the sample table (newest hardware first)

## Defaults chosen + rationale

- 8x B200 chassis (single HGX baseboard) is the canonical form factor; PCIe single-GPU SKUs exist but are not the primary enterprise buy
- `purchasePriceUSD: 500000` mid of the typical $450k-$650k street range; varies with HBM size (180/192 GB), cooling type, and host configuration
- `tdpWatts: 1000` per-GPU sticker TDP; sample notes to bump to 1200 for liquid-cooled SKUs drawing sustained higher load
- `amortizationYears: 3` and `maintenancePercentPerYear: 0.10` consistent with the H100 SXM5 sample for enterprise data center conventions
- US commercial electricity rate ($0.12/kWh, PUE 1.4) consistent with other enterprise samples
- Inline note: 8x 1000W GPUs draws ~14 kW per chassis once CPU + memory + cooling overhead are counted; flagged so operators don't get surprised by facility / PDU planning

## Procurement footnote in the sample

Real procurement quotes vary widely depending on configuration. The sample's $500k is a defensible starting number, with the inline comment instructing operators to update once their actual PO closes; the per-token math moves with it.

## DCGM integration note

Sample inline notes reference `dcgm-exporter 4.5+` for real-time per-GPU power attribution rather than the `tdpWatts` fallback. Aligns with the dcgm-exporter version floor recommended in the LLMKube B200 validation matrix doc (defilantech/LLMKube #414).

## Compatibility

Sample-only; no controller or chart changes. Existing CostProfiles continue to work unchanged.