### PR TITLE
fix(scraper): infer backend from inference.llmkube.dev/runtime label as fallback (closes #45)

### DIFF
--- a/internal/controller/costprofile_controller.go
+++ b/internal/controller/costprofile_controller.go
@@ -251,7 +251,11 @@ func (r *CostProfileReconciler) scrapeInferencePods(ctx context.Context, profile
 		}
 
 		// Dispatch to llama.cpp or vLLM based on pod annotations/labels.
-		backend := scraper.ResolveBackend(pod.Annotations, pod.Labels)
+		backend, source := scraper.ResolveBackendWithSource(pod.Annotations, pod.Labels)
+		if source == scraper.BackendSourceLLMKubeRuntime {
+			log.Info("inferred backend from LLMKube runtime label",
+				"pod", pod.Name, "namespace", pod.Namespace, "backend", backend, "source", source.String())
+		}
 		port := scraper.ResolveMetricsPort(backend, pod.Annotations, pod.Labels)
 		endpoint := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, port)
 		im, err := scraper.Scrape(ctx, r.ScrapeClient, backend, endpoint)

--- a/internal/controller/usagereport_controller.go
+++ b/internal/controller/usagereport_controller.go
@@ -245,7 +245,11 @@ func (r *UsageReportReconciler) scrapeTokens(ctx context.Context, report *finops
 		if !podIsScrapeable(pod, nsFilter) {
 			continue
 		}
-		backend := scraper.ResolveBackend(pod.Annotations, pod.Labels)
+		backend, source := scraper.ResolveBackendWithSource(pod.Annotations, pod.Labels)
+		if source == scraper.BackendSourceLLMKubeRuntime {
+			log.Info("inferred backend from LLMKube runtime label",
+				"pod", pod.Name, "namespace", pod.Namespace, "backend", backend, "source", source.String())
+		}
 		port := scraper.ResolveMetricsPort(backend, pod.Annotations, pod.Labels)
 		endpoint := fmt.Sprintf("http://%s:%d/metrics", pod.Status.PodIP, port)
 		im, err := scraper.Scrape(ctx, r.ScrapeClient, backend, endpoint)

--- a/internal/scraper/backend.go
+++ b/internal/scraper/backend.go
@@ -26,6 +26,14 @@ const (
 	//   llamacpp: 8080
 	//   vllm:     8000
 	MetricsPortAnnotation = "infercost.ai/metrics-port"
+	// LLMKubeRuntimeLabel is the pod label LLMKube applies to inference
+	// pods identifying the runtime backend. ResolveBackend reads this as
+	// a fallback when neither the InferCost annotation nor label is set,
+	// so users running InferCost alongside LLMKube get correct backend
+	// detection out of the box without an extra annotation.
+	//
+	// Reference: github.com/defilantech/LLMKube PR #410.
+	LLMKubeRuntimeLabel = "inference.llmkube.dev/runtime"
 )
 
 // DefaultPort returns the conventional /metrics port for a backend.
@@ -38,17 +46,68 @@ func (b Backend) DefaultPort() int {
 	}
 }
 
+// BackendSource records which lookup rule produced a backend so callers can
+// log appropriately when a non-explicit fallback fired. The order also
+// reflects precedence: lower-numbered sources beat higher-numbered ones.
+type BackendSource int
+
+const (
+	// BackendSourceAnnotation: explicit infercost.ai/backend annotation.
+	BackendSourceAnnotation BackendSource = iota
+	// BackendSourceLabel: explicit infercost.ai/backend label.
+	BackendSourceLabel
+	// BackendSourceLLMKubeRuntime: inferred from inference.llmkube.dev/runtime
+	// label that LLMKube emits on its inference pods. Fires when neither
+	// InferCost annotation nor label is present.
+	BackendSourceLLMKubeRuntime
+	// BackendSourceDefault: nothing matched, fell back to llama.cpp.
+	BackendSourceDefault
+)
+
+func (s BackendSource) String() string {
+	switch s {
+	case BackendSourceAnnotation:
+		return "infercost.ai/backend annotation"
+	case BackendSourceLabel:
+		return "infercost.ai/backend label"
+	case BackendSourceLLMKubeRuntime:
+		return LLMKubeRuntimeLabel + " label (LLMKube)"
+	default:
+		return "default (no backend hint found)"
+	}
+}
+
 // ResolveBackend picks a backend from pod annotations or labels, falling back
-// to llama.cpp. Annotations take precedence over labels so users can override
-// the backend without relabeling pods that might be owned by a controller.
+// to llama.cpp. Precedence:
+//
+//  1. infercost.ai/backend annotation (explicit override)
+//  2. infercost.ai/backend label (explicit override at label level)
+//  3. inference.llmkube.dev/runtime label (LLMKube emits this; we read it as a
+//     fallback so InferCost works out of the box alongside LLMKube)
+//  4. default to llama.cpp
+//
+// Returns just the resolved backend; callers that want to log which rule
+// fired should use ResolveBackendWithSource.
 func ResolveBackend(annotations, labels map[string]string) Backend {
+	b, _ := ResolveBackendWithSource(annotations, labels)
+	return b
+}
+
+// ResolveBackendWithSource is the explicit-source variant of ResolveBackend.
+// Used by the controller scrape loops so they can log "inferred backend from
+// LLMKube runtime label" at info level when rule 3 fires, making the
+// behavior visible to operators without surprising them.
+func ResolveBackendWithSource(annotations, labels map[string]string) (Backend, BackendSource) {
 	if v, ok := annotations[BackendAnnotation]; ok {
-		return normalizeBackend(v)
+		return normalizeBackend(v), BackendSourceAnnotation
 	}
 	if v, ok := labels[BackendAnnotation]; ok {
-		return normalizeBackend(v)
+		return normalizeBackend(v), BackendSourceLabel
 	}
-	return BackendLlamaCPP
+	if v, ok := labels[LLMKubeRuntimeLabel]; ok && v != "" {
+		return normalizeBackend(v), BackendSourceLLMKubeRuntime
+	}
+	return BackendLlamaCPP, BackendSourceDefault
 }
 
 func normalizeBackend(v string) Backend {

--- a/internal/scraper/backend_test.go
+++ b/internal/scraper/backend_test.go
@@ -37,6 +37,112 @@ func TestResolveBackend_UnknownFallsBackToLlamaCPP(t *testing.T) {
 	}
 }
 
+// LLMKube emits inference.llmkube.dev/runtime on its inference pods. When
+// neither InferCost annotation nor label is present, ResolveBackend uses
+// that label as a fallback so InferCost works out of the box alongside
+// LLMKube without an extra annotation step. See InferCost issue #45.
+func TestResolveBackend_LLMKubeRuntimeLabelFallback_VLLM(t *testing.T) {
+	labels := map[string]string{LLMKubeRuntimeLabel: "vllm"}
+	if got := ResolveBackend(nil, labels); got != BackendVLLM {
+		t.Errorf("LLMKube runtime=vllm should resolve to BackendVLLM, got %q", got)
+	}
+}
+
+func TestResolveBackend_LLMKubeRuntimeLabelFallback_LlamaCPP(t *testing.T) {
+	labels := map[string]string{LLMKubeRuntimeLabel: "llamacpp"}
+	if got := ResolveBackend(nil, labels); got != BackendLlamaCPP {
+		t.Errorf("LLMKube runtime=llamacpp should resolve to BackendLlamaCPP, got %q", got)
+	}
+}
+
+// Explicit override (rule 1) still wins over the LLMKube label (rule 3).
+func TestResolveBackend_AnnotationBeatsLLMKubeLabel(t *testing.T) {
+	annotations := map[string]string{BackendAnnotation: "llamacpp"}
+	labels := map[string]string{LLMKubeRuntimeLabel: "vllm"}
+	if got := ResolveBackend(annotations, labels); got != BackendLlamaCPP {
+		t.Errorf("InferCost annotation must beat LLMKube label, got %q", got)
+	}
+}
+
+// InferCost label override (rule 2) still wins over the LLMKube label (rule 3).
+func TestResolveBackend_InferCostLabelBeatsLLMKubeLabel(t *testing.T) {
+	labels := map[string]string{
+		BackendAnnotation:   "llamacpp",
+		LLMKubeRuntimeLabel: "vllm",
+	}
+	if got := ResolveBackend(nil, labels); got != BackendLlamaCPP {
+		t.Errorf("InferCost label must beat LLMKube label, got %q", got)
+	}
+}
+
+// Unknown LLMKube runtime values (e.g. "tgi", "personaplex") fall through to
+// llamacpp default rather than erroring; we treat unknowns as non-fatal so
+// new LLMKube runtimes don't break InferCost installs that haven't bumped.
+func TestResolveBackend_UnknownLLMKubeRuntimeFallsBackToLlamaCPP(t *testing.T) {
+	labels := map[string]string{LLMKubeRuntimeLabel: "tgi"}
+	if got := ResolveBackend(nil, labels); got != BackendLlamaCPP {
+		t.Errorf("unknown LLMKube runtime should fall back to llamacpp, got %q", got)
+	}
+}
+
+// Empty LLMKube label value (someone applied it but cleared the value)
+// falls through to the default rather than treating "" as a runtime hint.
+func TestResolveBackend_EmptyLLMKubeRuntimeFallsBackToDefault(t *testing.T) {
+	labels := map[string]string{LLMKubeRuntimeLabel: ""}
+	got, source := ResolveBackendWithSource(nil, labels)
+	if got != BackendLlamaCPP {
+		t.Errorf("empty LLMKube runtime should fall back to llamacpp, got %q", got)
+	}
+	if source != BackendSourceDefault {
+		t.Errorf("empty LLMKube runtime should report BackendSourceDefault, got %v", source)
+	}
+}
+
+func TestResolveBackendWithSource_ReportsSource(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		wantBackend Backend
+		wantSource  BackendSource
+	}{
+		{
+			name:        "annotation source",
+			annotations: map[string]string{BackendAnnotation: "vllm"},
+			wantBackend: BackendVLLM,
+			wantSource:  BackendSourceAnnotation,
+		},
+		{
+			name:        "label source",
+			labels:      map[string]string{BackendAnnotation: "vllm"},
+			wantBackend: BackendVLLM,
+			wantSource:  BackendSourceLabel,
+		},
+		{
+			name:        "llmkube runtime source",
+			labels:      map[string]string{LLMKubeRuntimeLabel: "vllm"},
+			wantBackend: BackendVLLM,
+			wantSource:  BackendSourceLLMKubeRuntime,
+		},
+		{
+			name:        "default source",
+			wantBackend: BackendLlamaCPP,
+			wantSource:  BackendSourceDefault,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, s := ResolveBackendWithSource(tc.annotations, tc.labels)
+			if b != tc.wantBackend {
+				t.Errorf("backend = %q, want %q", b, tc.wantBackend)
+			}
+			if s != tc.wantSource {
+				t.Errorf("source = %v, want %v", s, tc.wantSource)
+			}
+		})
+	}
+}
+
 func TestDefaultPort(t *testing.T) {
 	if BackendLlamaCPP.DefaultPort() != 8080 {
 		t.Errorf("llamacpp default port = %d, want 8080", BackendLlamaCPP.DefaultPort())


### PR DESCRIPTION
## Summary

Adds a third precedence rule to `ResolveBackend` so InferCost picks up the right backend automatically when running alongside LLMKube. Closes #45.

New precedence:

1. `infercost.ai/backend` annotation (explicit override; unchanged)
2. `infercost.ai/backend` label (explicit override at label level; unchanged)
3. `inference.llmkube.dev/runtime` label (NEW; LLMKube emits this on its inference pods per [LLMKube PR #410](https://github.com/defilantech/LLMKube/pull/410))
4. default to llamacpp (unchanged)

## Background

LLMKube doesn't propagate arbitrary annotations to its pod templates ([LLMKube #326](https://github.com/defilantech/LLMKube/issues/326)), so users running both products historically had to `kubectl annotate` every pod out of band, or accept that InferCost would default to llamacpp and silently scrape the wrong endpoint when the pod was actually vLLM. This bit us during a recent deploy: the scraper hammered port 8080 on a vLLM pod, got connection-refused, reported zero tokens, and the UsageReport sat with empty fields.

## Implementation

- `internal/scraper/backend.go` gains `LLMKubeRuntimeLabel` constant and a `BackendSource` enum so callers can tell which rule fired without re-running the resolution. `ResolveBackend` is preserved as a backward-compatible thin wrapper around the new `ResolveBackendWithSource`.
- The two scrape loops (UsageReport + CostProfile controllers) now call `ResolveBackendWithSource` and emit an info-level log line when rule 3 fires: `inferred backend from LLMKube runtime label`. Not magic, just convenient; explicit is better than implicit.
- Empty LLMKube label values fall through to the default; only non-empty values participate in the inference.
- Unknown LLMKube runtime values (e.g. `tgi`, `personaplex`) are treated as llamacpp via the existing `normalizeBackend`, which is non-fatal so new LLMKube runtimes don't break InferCost installs that haven't bumped.

## Tests

`backend_test.go` adds 8 new cases covering:
- VLLM fallback path from LLMKube runtime label
- llamacpp fallback path from LLMKube runtime label
- Annotation precedence over LLMKube label (rule 1 still wins)
- InferCost label precedence over LLMKube label (rule 2 still wins)
- Unknown LLMKube runtime values → llamacpp default
- Empty LLMKube label value → default source (not LLMKube source)
- `ResolveBackendWithSource` reports the correct source for all four rules

```
$ go test ./internal/scraper/... -count=1
ok      github.com/defilantech/infercost/internal/scraper       0.351s

$ go test ./internal/controller/... -count=1
ok      github.com/defilantech/infercost/internal/controller    6.888s
```

## Compatibility

Behavior change is additive: pods without `infercost.ai/backend` annotation/label now resolve to a sensible backend instead of defaulting to llamacpp; pods with the explicit override are unaffected. `ResolveBackend` signature is preserved as a thin wrapper, so any external callers continue to work.

Closes #45