### PR TITLE
feat(cost-model): add active-hours-amortized $/MTok (closes #37)

### DIFF
--- a/api/v1alpha1/usagereport_types.go
+++ b/api/v1alpha1/usagereport_types.go
@@ -143,6 +143,16 @@ type UsageReportStatus struct {
 	// +optional
 	MarginalCostPerMillionTokens float64 `json:"marginalCostPerMillionTokens,omitempty"`
 
+	// activeHoursCostPerMillionTokens amortizes the full hourly cost (hardware
+	// amortization + electricity) over only the hours the GPUs were actively
+	// serving (capped at the wall-clock period). It sits between
+	// marginalCostPerMillionTokens (electricity only) and costPerMillionTokens
+	// (full wall-clock amortization): the cost per token if the hardware only
+	// cost money while it was working. Useful for sizing/efficiency comparisons
+	// that should not be penalized by idle hours.
+	// +optional
+	ActiveHoursCostPerMillionTokens float64 `json:"activeHoursCostPerMillionTokens,omitempty"`
+
 	// activeEnergyKWh is the integrated energy drawn during active-threshold
 	// time across the reporting period, derived from DCGM power samples.
 	// Surfaced directly so operators can sanity-check the marginal cost math.
@@ -204,6 +214,7 @@ type UsageReportStatus struct {
 // +kubebuilder:printcolumn:name="Cost ($)",type=number,JSONPath=`.status.estimatedCostUSD`,format=float
 // +kubebuilder:printcolumn:name="$/MTok",type=number,JSONPath=`.status.costPerMillionTokens`,format=float
 // +kubebuilder:printcolumn:name="$/MTok (marginal)",type=number,JSONPath=`.status.marginalCostPerMillionTokens`,format=float,priority=1
+// +kubebuilder:printcolumn:name="$/MTok (active)",type=number,JSONPath=`.status.activeHoursCostPerMillionTokens`,format=float,priority=1
 // +kubebuilder:printcolumn:name="Input Tokens",type=integer,JSONPath=`.status.inputTokens`
 // +kubebuilder:printcolumn:name="Output Tokens",type=integer,JSONPath=`.status.outputTokens`
 // +kubebuilder:printcolumn:name="Util %",type=number,JSONPath=`.status.utilizationPercent`,format=float,priority=1

--- a/charts/infercost/templates/crds/usagereports.yaml
+++ b/charts/infercost/templates/crds/usagereports.yaml
@@ -32,6 +32,11 @@ spec:
       name: $/MTok (marginal)
       priority: 1
       type: number
+    - format: float
+      jsonPath: .status.activeHoursCostPerMillionTokens
+      name: $/MTok (active)
+      priority: 1
+      type: number
     - jsonPath: .status.inputTokens
       name: Input Tokens
       type: integer
@@ -109,6 +114,16 @@ spec:
                   activeEnergyKWh is the integrated energy drawn during active-threshold
                   time across the reporting period, derived from DCGM power samples.
                   Surfaced directly so operators can sanity-check the marginal cost math.
+                type: number
+              activeHoursCostPerMillionTokens:
+                description: |-
+                  activeHoursCostPerMillionTokens amortizes the full hourly cost (hardware
+                  amortization + electricity) over only the hours the GPUs were actively
+                  serving (capped at the wall-clock period). It sits between
+                  marginalCostPerMillionTokens (electricity only) and costPerMillionTokens
+                  (full wall-clock amortization): the cost per token if the hardware only
+                  cost money while it was working. Useful for sizing/efficiency comparisons
+                  that should not be penalized by idle hours.
                 type: number
               activeHoursInPeriod:
                 description: |-

--- a/config/crd/bases/finops.infercost.ai_usagereports.yaml
+++ b/config/crd/bases/finops.infercost.ai_usagereports.yaml
@@ -31,6 +31,11 @@ spec:
       name: $/MTok (marginal)
       priority: 1
       type: number
+    - format: float
+      jsonPath: .status.activeHoursCostPerMillionTokens
+      name: $/MTok (active)
+      priority: 1
+      type: number
     - jsonPath: .status.inputTokens
       name: Input Tokens
       type: integer
@@ -108,6 +113,16 @@ spec:
                   activeEnergyKWh is the integrated energy drawn during active-threshold
                   time across the reporting period, derived from DCGM power samples.
                   Surfaced directly so operators can sanity-check the marginal cost math.
+                type: number
+              activeHoursCostPerMillionTokens:
+                description: |-
+                  activeHoursCostPerMillionTokens amortizes the full hourly cost (hardware
+                  amortization + electricity) over only the hours the GPUs were actively
+                  serving (capped at the wall-clock period). It sits between
+                  marginalCostPerMillionTokens (electricity only) and costPerMillionTokens
+                  (full wall-clock amortization): the cost per token if the hardware only
+                  cost money while it was working. Useful for sizing/efficiency comparisons
+                  that should not be penalized by idle hours.
                 type: number
               activeHoursInPeriod:
                 description: |-

--- a/internal/calculator/calculator.go
+++ b/internal/calculator/calculator.go
@@ -88,6 +88,28 @@ func ComputeCostPerToken(hourlyCost, tokensPerHour float64) float64 {
 	return hourlyCost / tokensPerHour
 }
 
+// ActiveHoursCostPerMillionTokens amortizes the full hourly cost (hardware
+// amortization + electricity) over only the hours the GPUs were actively
+// serving, then divides by tokens. activeHours is capped at wallClockHours to
+// guard against sampler overcount (e.g. a sampler that just started or a
+// controller restart can report more active hours than the window).
+//
+// This sits between the electricity-only marginal cost (lower bound) and the
+// fully-loaded wall-clock cost (true cost of ownership, upper bound): it answers
+// "what would a token cost if the hardware only cost money while it was working?"
+// Returns 0 when there are no tokens, no active hours, or no hourly cost.
+func ActiveHoursCostPerMillionTokens(hourlyCost, activeHours, wallClockHours float64, totalTokens int64) float64 {
+	if totalTokens <= 0 || activeHours <= 0 || hourlyCost <= 0 {
+		return 0
+	}
+	effectiveActiveHours := activeHours
+	if wallClockHours > 0 && effectiveActiveHours > wallClockHours {
+		effectiveActiveHours = wallClockHours
+	}
+	activeHoursCost := hourlyCost * effectiveActiveHours
+	return activeHoursCost / (float64(totalTokens) / 1_000_000.0)
+}
+
 // ComputeFull runs the complete cost calculation pipeline.
 func ComputeFull(hw HardwareCosts, powerDrawWatts float64, prev, curr TokenSnapshot) CostResult {
 	amort, elec, total := ComputeHourlyCost(hw, powerDrawWatts)

--- a/internal/calculator/calculator_test.go
+++ b/internal/calculator/calculator_test.go
@@ -640,3 +640,53 @@ func TestCompareToCloud_EmptyPricing(t *testing.T) {
 		t.Errorf("expected 0 results for empty pricing, got %d", len(results))
 	}
 }
+
+func TestActiveHoursCostPerMillionTokens(t *testing.T) {
+	tests := []struct {
+		name           string
+		hourlyCost     float64
+		activeHours    float64
+		wallClockHours float64
+		totalTokens    int64
+		want           float64
+	}{
+		{
+			name:       "amortizes over active hours only",
+			hourlyCost: 0.5, activeHours: 4, wallClockHours: 24, totalTokens: 4_000_000,
+			want: 0.5, // (0.5 * 4) / (4M/1M) = 2.0 / 4 = 0.5
+		},
+		{
+			name:       "far below fully-loaded at low utilization",
+			hourlyCost: 1.0, activeHours: 2, wallClockHours: 24, totalTokens: 1_000_000,
+			want: 2.0, // active: (1*2)/1 = 2; fully-loaded would be (1*24)/1 = 24
+		},
+		{
+			name:       "caps active hours at wall-clock to guard sampler overcount",
+			hourlyCost: 1.0, activeHours: 100, wallClockHours: 24, totalTokens: 1_000_000,
+			want: 24.0, // min(100,24) = 24
+		},
+		{
+			name:       "zero tokens yields zero",
+			hourlyCost: 1.0, activeHours: 4, wallClockHours: 24, totalTokens: 0,
+			want: 0,
+		},
+		{
+			name:       "zero active hours yields zero",
+			hourlyCost: 1.0, activeHours: 0, wallClockHours: 24, totalTokens: 1_000_000,
+			want: 0,
+		},
+		{
+			name:       "zero hourly cost yields zero",
+			hourlyCost: 0, activeHours: 4, wallClockHours: 24, totalTokens: 1_000_000,
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ActiveHoursCostPerMillionTokens(tc.hourlyCost, tc.activeHours, tc.wallClockHours, tc.totalTokens)
+			if !almostEqual(got, tc.want) {
+				t.Errorf("ActiveHoursCostPerMillionTokens() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/usagereport_controller.go
+++ b/internal/controller/usagereport_controller.go
@@ -34,6 +34,7 @@ import (
 
 	finopsv1alpha1 "github.com/defilantech/infercost/api/v1alpha1"
 	internalapi "github.com/defilantech/infercost/internal/api"
+	"github.com/defilantech/infercost/internal/calculator"
 	"github.com/defilantech/infercost/internal/scraper"
 	"github.com/defilantech/infercost/internal/utilization"
 )
@@ -145,23 +146,30 @@ func (r *UsageReportReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}
 
+	// Active-hours amortized $/MTok: charge the full hourly cost over only the
+	// hours the GPUs actually served (capped at wall-clock), so the figure is
+	// not dominated by idle hours. Sits between marginal and fully-loaded.
+	activeHoursCostPerMillion := calculator.ActiveHoursCostPerMillionTokens(
+		profile.Status.HourlyCostUSD, activeHours, hoursInPeriod, totalTokens)
+
 	periodStr := formatPeriod(report.Spec.Schedule, periodStart)
 	computed := computedStatus{
-		period:                       periodStr,
-		periodStart:                  periodStart,
-		periodEnd:                    periodEnd,
-		inputTokens:                  totalIn,
-		outputTokens:                 totalOut,
-		totalCost:                    totalCost,
-		costPerMillionTokens:         costPerMillion,
-		marginalCostPerMillionTokens: marginalCostPerMillion,
-		activeEnergyKWh:              activeEnergyKWh,
-		byModel:                      byModel,
-		byNamespace:                  byNamespace,
-		utilizationPercent:           utilizationPercent,
-		gpuEfficiencyRatio:           gpuEfficiency,
-		activeHoursInPeriod:          activeHours,
-		totalHoursInPeriod:           hoursInPeriod,
+		period:                          periodStr,
+		periodStart:                     periodStart,
+		periodEnd:                       periodEnd,
+		inputTokens:                     totalIn,
+		outputTokens:                    totalOut,
+		totalCost:                       totalCost,
+		costPerMillionTokens:            costPerMillion,
+		marginalCostPerMillionTokens:    marginalCostPerMillion,
+		activeHoursCostPerMillionTokens: activeHoursCostPerMillion,
+		activeEnergyKWh:                 activeEnergyKWh,
+		byModel:                         byModel,
+		byNamespace:                     byNamespace,
+		utilizationPercent:              utilizationPercent,
+		gpuEfficiencyRatio:              gpuEfficiency,
+		activeHoursInPeriod:             activeHours,
+		totalHoursInPeriod:              hoursInPeriod,
 	}
 	// Silence unused-var warning when sampler is wired but period has no observations yet.
 	_ = totalHoursObserved
@@ -364,17 +372,18 @@ func buildBreakdowns(
 // passed from the computation phase to the write phase so the Reconcile entry
 // point stays short enough to read top-to-bottom.
 type computedStatus struct {
-	period                       string
-	periodStart                  time.Time
-	periodEnd                    time.Time
-	inputTokens                  int64
-	outputTokens                 int64
-	totalCost                    float64
-	costPerMillionTokens         float64
-	marginalCostPerMillionTokens float64
-	activeEnergyKWh              float64
-	byModel                      []finopsv1alpha1.ModelCostBreakdown
-	byNamespace                  []finopsv1alpha1.NamespaceCostBreakdown
+	period                          string
+	periodStart                     time.Time
+	periodEnd                       time.Time
+	inputTokens                     int64
+	outputTokens                    int64
+	totalCost                       float64
+	costPerMillionTokens            float64
+	marginalCostPerMillionTokens    float64
+	activeHoursCostPerMillionTokens float64
+	activeEnergyKWh                 float64
+	byModel                         []finopsv1alpha1.ModelCostBreakdown
+	byNamespace                     []finopsv1alpha1.NamespaceCostBreakdown
 	// utilization-derived fields (all zero when no sampler is wired)
 	utilizationPercent  float64
 	gpuEfficiencyRatio  float64
@@ -402,6 +411,7 @@ func (r *UsageReportReconciler) applyStatusIfChanged(ctx context.Context, report
 	report.Status.EstimatedCostUSD = c.totalCost
 	report.Status.CostPerMillionTokens = c.costPerMillionTokens
 	report.Status.MarginalCostPerMillionTokens = c.marginalCostPerMillionTokens
+	report.Status.ActiveHoursCostPerMillionTokens = c.activeHoursCostPerMillionTokens
 	report.Status.ActiveEnergyKWh = c.activeEnergyKWh
 	report.Status.ByModel = c.byModel
 	report.Status.ByNamespace = c.byNamespace


### PR DESCRIPTION
## What

Adds a third cost lens to `UsageReport` status: **`activeHoursCostPerMillionTokens`** — the full hourly cost (hardware amortization + electricity) amortized over only the hours the GPUs were *actively serving*, divided by tokens.

## Why

Fixes #37

`costPerMillionTokens` amortizes over the full wall-clock window, so a cluster that served a few thousand tokens in a day has 24h of idle GPU amortization charged against those tokens. The headline `$/MTok` is then dominated by idle time, making every cloud provider look thousands of percent cheaper and undercutting the tool's credibility at low utilization.

This adds an idle-insensitive lens that sits between the two existing ones:
- `marginalCostPerMillionTokens` — electricity only, active hours (lower bound)
- **`activeHoursCostPerMillionTokens`** — full cost, active hours only (new)
- `costPerMillionTokens` — full cost, all wall-clock hours (true cost of ownership, upper bound)

`costPerMillionTokens` is intentionally left unchanged: it remains the honest cost-of-ownership figure (idle GPUs are real sunk cost). Per #41, these lenses are meant to be read together with utilization context.

## How

- Pure, unit-tested helper `calculator.ActiveHoursCostPerMillionTokens(hourlyCost, activeHours, wallClockHours, totalTokens)` — caps `activeHours` at `wallClockHours` to guard sampler overcount; returns 0 for no tokens / no active hours / no cost. 6 table cases.
- `UsageReportReconciler.Reconcile` calls it with the sampler's `activeHours` (0 when no sampler → field is 0/omitted).
- New `activeHoursCostPerMillionTokens` status field + a `$/MTok (active)` print column (priority=1).
- Follows the existing field's treatment: excluded from `usageReportStatusContentEqual` (sampler-derived, same as `marginalCostPerMillionTokens`, avoids a status hot-loop).
- Regenerated CRDs (`config/crd/bases` + chart CRDs via `make chart-crds`).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] Documentation updated (CRD field doc-comments + print column)
